### PR TITLE
Allow callers to wait for the StubbyClient to finish

### DIFF
--- a/main/java/by/stub/client/StubbyClient.java
+++ b/main/java/by/stub/client/StubbyClient.java
@@ -156,7 +156,7 @@ public final class StubbyClient {
    }
 
    /**
-    * Blocks until Jetty it stopped
+    * Blocks until Jetty has finished
     *
     * @throws Exception
     */

--- a/main/java/by/stub/client/StubbyClient.java
+++ b/main/java/by/stub/client/StubbyClient.java
@@ -156,6 +156,18 @@ public final class StubbyClient {
    }
 
    /**
+    * Blocks until Jetty it stopped
+    *
+    * @throws Exception
+    */
+   @CoberturaIgnore
+   public void joinJetty() throws Exception {
+      if (ObjectUtils.isNotNull(stubbyManager)) {
+         stubbyManager.joinJetty();
+      }
+   }
+
+   /**
     * Makes GET HTTP request to stubby
     *
     * @param host      host that stubby4j is running on

--- a/main/java/by/stub/server/StubbyManager.java
+++ b/main/java/by/stub/server/StubbyManager.java
@@ -62,6 +62,10 @@ public final class StubbyManager {
       ANSITerminal.status("Jetty successfully shutdown");
    }
 
+   public synchronized void joinJetty() throws Exception {
+      server.join();
+   }
+
    private boolean isJettyStarting() throws Exception {
       return server.isStarting();
    }


### PR DESCRIPTION
This change introduces the joinJetty method which blocks the calling
 thread until the StubbyClient has finished.