### PR TITLE
Dynamic token replacement in stubbed response has been applied for re…

### DIFF
--- a/main/java/io/github/azagniotov/stubby4j/handlers/strategy/stubs/DefaultResponseHandlingStrategy.java
+++ b/main/java/io/github/azagniotov/stubby4j/handlers/strategy/stubs/DefaultResponseHandlingStrategy.java
@@ -43,7 +43,7 @@ public final class DefaultResponseHandlingStrategy implements StubResponseHandli
     @Override
     public void handle(final HttpServletResponse response, final StubRequest assertionStubRequest) throws Exception {
         HandlerUtils.setResponseMainHeaders(response);
-        setStubResponseHeaders(foundStubResponse, response);
+        setStubResponseHeaders(foundStubResponse, assertionStubRequest, response);
 
         if (StringUtils.isSet(foundStubResponse.getLatency())) {
             final long latency = Long.parseLong(foundStubResponse.getLatency());
@@ -73,10 +73,14 @@ public final class DefaultResponseHandlingStrategy implements StubResponseHandli
         streamOut.close();
     }
 
-    private void setStubResponseHeaders(final StubResponse stubResponse, final HttpServletResponse response) {
+    private void setStubResponseHeaders(final StubResponse stubResponse, final StubRequest assertionStubRequest, final HttpServletResponse response) {
         response.setCharacterEncoding(StringUtils.UTF_8);
         for (Map.Entry<String, String> entry : stubResponse.getHeaders().entrySet()) {
-            response.setHeader(entry.getKey(), entry.getValue());
+            String responseHeaderValue = entry.getValue();
+            if (entry.getValue().contains(StringUtils.TEMPLATE_TOKEN_LEFT)) {
+                responseHeaderValue = StringUtils.replaceTokens(entry.getValue().getBytes(), assertionStubRequest.getRegexGroups());
+            }
+            response.setHeader(entry.getKey(), responseHeaderValue);
         }
     }
 }


### PR DESCRIPTION
…sponse headers as well.

Hi There,

Yesterday faced with issue when I can't use token replacement in response headers. So for example I can't define regex group somewhere in request and then use it in response header like "location" but only in response body. So decided to fix it. Please advise in case of any concerns how to do it in the best way.

Thanks, Dzmitry.