### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For more information and more complex examples, please dive into the rest of doc
 * Embed stubby4j to create a web service SANDBOX for your integration test suite
 
 ### Why would a developer use stubby4j?
-####You want to:
+#### You want to:
 * Simulate responses from real server and don't care (or cannot) to go over the network
 * Third party web service your application suppose to contract with is not ready yet
 * Verify that your code makes HTTP requests with all the required parameters and/or headers


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
