### PR TITLE
Add endpoint to Delete all stubs

### DIFF
--- a/functional/java/io/github/azagniotov/stubby4j/AdminPortalTest.java
+++ b/functional/java/io/github/azagniotov/stubby4j/AdminPortalTest.java
@@ -391,21 +391,6 @@ public class AdminPortalTest {
     }
 
     @Test
-    public void should_ReturnExpectedError_WhenSuccessfulDeleteMade_ToAdminPortalRoot() throws Exception {
-
-        final String requestUrl = String.format("%s/", ADMIN_URL);
-        final HttpRequest httpPutRequest = HttpUtils.constructHttpRequest(HttpMethods.DELETE, requestUrl);
-
-        final HttpResponse httpResponse = httpPutRequest.execute();
-        final String statusMessage = httpResponse.getStatusMessage().trim();
-        final String responseMessage = httpResponse.parseAsString().trim();
-
-        assertThat(httpResponse.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED_405);
-        assertThat(statusMessage).isEqualTo("Method Not Allowed");
-        assertThat(responseMessage).isEqualTo("Method DELETE is not allowed on URI /");
-    }
-
-    @Test
     public void should_ReturnExpectedError_WhenSuccessfulDeleteMade_ToAdminPortalRootWithInvalidIndexURI() throws Exception {
 
         final int invalidIndex = 88888888;
@@ -450,6 +435,38 @@ public class AdminPortalTest {
 
         assertThat(HttpStatus.OK_200).isEqualTo(httpGetResponse.getStatusCode());
         assertThat(getResponseContent).doesNotContain("url: ^/[a-z]{3}-[a-z]{3}/[0-9]{2}/[A-Z]{2}/[a-z0-9]+\\?paramOne=[a-zA-Z]{3,8}&paramTwo=[a-zA-Z]{3,8}");
+    }
+
+    @Test
+    public void should_DeleteAllStubbedRequests_WhenSuccessfulDeleteMade_ToAdminPortalRootWithValidIndexURI() throws Exception {
+
+        final String requestUrl = String.format("%s%s", ADMIN_URL, "/2");
+        HttpRequest httpGetRequest = HttpUtils.constructHttpRequest(HttpMethods.GET, requestUrl);
+        HttpResponse httpGetResponse = httpGetRequest.execute();
+        String getResponseContent = httpGetResponse.parseAsString().trim();
+
+        assertThat(HttpStatus.OK_200).isEqualTo(httpGetResponse.getStatusCode());
+        assertThat(getResponseContent).contains("request");
+        assertThat(getResponseContent).contains("url: ^/[a-z]{3}-[a-z]{3}/[0-9]{2}/[A-Z]{2}/[a-z0-9]+\\?paramOne=[a-zA-Z]{3,8}&paramTwo=[a-zA-Z]{3,8}");
+        assertThat(getResponseContent).contains("response");
+        assertThat(getResponseContent).contains("content-type: application/json");
+
+
+        final String deleteAllRequestUrl = String.format("%s", ADMIN_URL);
+        final HttpRequest httpDeleteRequest = HttpUtils.constructHttpRequest(HttpMethods.DELETE, deleteAllRequestUrl);
+
+        final HttpResponse httpDeleteResponse = httpDeleteRequest.execute();
+        final String deleteResponseContent = httpDeleteResponse.parseAsString().trim();
+
+        assertThat(HttpStatus.OK_200).isEqualTo(httpDeleteResponse.getStatusCode());
+        assertThat(deleteResponseContent).isEqualTo("Stub requests deleted successfully");
+
+        httpGetRequest = HttpUtils.constructHttpRequest(HttpMethods.GET, deleteAllRequestUrl);
+        httpGetResponse = httpGetRequest.execute();
+        getResponseContent = httpGetResponse.parseAsString().trim();
+
+        assertThat(HttpStatus.OK_200).isEqualTo(httpGetResponse.getStatusCode());
+        assertThat(getResponseContent).isEmpty();
     }
 
 

--- a/main/java/io/github/azagniotov/stubby4j/handlers/strategy/admin/DeleteHandlingStrategy.java
+++ b/main/java/io/github/azagniotov/stubby4j/handlers/strategy/admin/DeleteHandlingStrategy.java
@@ -14,8 +14,9 @@ public class DeleteHandlingStrategy implements AdminResponseHandlingStrategy {
     public void handle(final HttpServletRequest request, final HttpServletResponse response, final StubRepository stubRepository) throws IOException {
 
         if (request.getRequestURI().equals(AdminPortalHandler.ADMIN_ROOT)) {
-            response.setStatus(HttpStatus.METHOD_NOT_ALLOWED_405);
-            response.getWriter().println("Method DELETE is not allowed on URI " + request.getRequestURI());
+            stubRepository.deleteAllStubs();
+            response.setStatus(HttpStatus.OK_200);
+            response.getWriter().println("Stub requests deleted successfully");
             return;
         }
 

--- a/main/java/io/github/azagniotov/stubby4j/stubs/StubRepository.java
+++ b/main/java/io/github/azagniotov/stubby4j/stubs/StubRepository.java
@@ -288,6 +288,10 @@ public class StubRepository {
         return removedStub;
     }
 
+    public synchronized void deleteAllStubs() {
+        stubs.clear();
+    }
+
     private void updateResourceIDHeaders() {
         for (int index = 0; index < stubs.size(); index++) {
             stubs.get(index).setResourceId(index);

--- a/unit/java/io/github/azagniotov/stubby4j/stubs/StubRepositoryTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/stubs/StubRepositoryTest.java
@@ -128,6 +128,23 @@ public class StubRepositoryTest {
     }
 
     @Test
+    public void shouldDeleteOriginalHttpCycleList_WhenStubsExist() throws Exception {
+        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
+        final boolean resetResult = spyStubRepository.resetStubsCache(stubs);
+        assertThat(resetResult).isTrue();
+        assertThat(spyStubRepository.getStubs().size()).isGreaterThan(0);
+
+        spyStubRepository.deleteAllStubs();
+        assertThat(spyStubRepository.getStubs()).isEmpty();
+    }
+
+    @Test
+    public void shouldDeleteOriginalHttpCycleList_WhenStubsDontExist() throws Exception {
+        spyStubRepository.deleteAllStubs();
+        assertThat(spyStubRepository.getStubs()).isEmpty();
+    }
+
+    @Test
     public void shouldDeleteOriginalHttpCycleList_WhenInvalidIndexGiven() throws Exception {
 
         expectedException.expect(IndexOutOfBoundsException.class);


### PR DESCRIPTION
I need a feature to implement tear down in my tests. Instead of having to loop over all registered stubs and delete them one by one, it is much easier to have a "delete all" endpoint exposed. This pull request provides this feature.