### PR TITLE
Allow custom xml and json content types

### DIFF
--- a/unit/java/io/github/azagniotov/stubby4j/stubs/StubMatcherTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/stubs/StubMatcherTest.java
@@ -313,4 +313,28 @@ public class StubMatcherTest {
 
         assertThat(isBodiesMatch).isFalse();
     }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenStringMatchWeirdContentType() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("wibble")
+                .withHeaderContentType("whut")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "wibble", request);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnFalse_WhenStringMatchWeirdContentType() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("wobble")
+                .withHeaderContentType("whut")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "wibble", request);
+
+        assertThat(isBodiesMatch).isFalse();
+    }
 }

--- a/unit/java/io/github/azagniotov/stubby4j/stubs/StubMatcherTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/stubs/StubMatcherTest.java
@@ -224,7 +224,7 @@ public class StubMatcherTest {
     public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentCustomJson() {
         StubRequest request = new StubRequest.Builder()
                 .withPost("{\"a\":\"b\",\"c\":\"d\"}")
-                .withHeaderContentType("application/vnd.com+json")
+                .withHeaderContentType("something/vnd.com+json")
                 .build();
 
         final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "{\"c\":\"d\",\"a\":\"b\"}", request);
@@ -236,7 +236,7 @@ public class StubMatcherTest {
     public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentCustomJsonCharset() {
         StubRequest request = new StubRequest.Builder()
                 .withPost("{\"a\":\"b\",\"c\":\"d\"}")
-                .withHeaderContentType("application/vnd.com+json;charset=stuff")
+                .withHeaderContentType("something/vnd.com+json;charset=stuff")
                 .build();
 
         final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "{\"c\":\"d\",\"a\":\"b\"}", request);
@@ -272,7 +272,7 @@ public class StubMatcherTest {
     public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentCustomXml() {
         StubRequest request = new StubRequest.Builder()
                 .withPost("<xml><a>a</a><b>b</b></xml>")
-                .withHeaderContentType("application/vnd.com+xml")
+                .withHeaderContentType("something/vnd.com+xml")
                 .build();
 
         final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "<xml><b>b</b><a>a</a></xml>", request);
@@ -284,7 +284,7 @@ public class StubMatcherTest {
     public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentCustomXmlCharset() {
         StubRequest request = new StubRequest.Builder()
                 .withPost("<xml><a>a</a><b>b</b></xml>")
-                .withHeaderContentType("application/vnd.com+xml;charset=something")
+                .withHeaderContentType("something/vnd.com+xml;charset=something")
                 .build();
 
         final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "<xml><b>b</b><a>a</a></xml>", request);

--- a/unit/java/io/github/azagniotov/stubby4j/stubs/StubMatcherTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/stubs/StubMatcherTest.java
@@ -168,4 +168,149 @@ public class StubMatcherTest {
 
         assertThat(isMapsMatch).isTrue();
     }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenIsPostStubbedFalse() {
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(false, null, null);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnFalse_WhenAssertingPostBodyNull() {
+        StubRequest request = new StubRequest.Builder().build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, null, request);
+
+        assertThat(isBodiesMatch).isFalse();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnFalse_WhenAssertingBodyWhitespace() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("  ")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, null, request);
+
+        assertThat(isBodiesMatch).isFalse();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnFalse_WhenDifferentJson() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("{\"name\":\"bob\"}")
+                .withHeaderContentType("application/json")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "{\"name\":\"tod\"}", request);
+
+        assertThat(isBodiesMatch).isFalse();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentJson() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("{\"a\":\"b\",\"c\":\"d\"}")
+                .withHeaderContentType("application/json")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "{\"c\":\"d\",\"a\":\"b\"}", request);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentCustomJson() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("{\"a\":\"b\",\"c\":\"d\"}")
+                .withHeaderContentType("application/vnd.com+json")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "{\"c\":\"d\",\"a\":\"b\"}", request);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentCustomJsonCharset() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("{\"a\":\"b\",\"c\":\"d\"}")
+                .withHeaderContentType("application/vnd.com+json;charset=stuff")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "{\"c\":\"d\",\"a\":\"b\"}", request);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnFalse_WhenDifferentXml() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("<xml>one</xml>")
+                .withHeaderContentType("application/xml")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "<xml>two</xml>", request);
+
+        assertThat(isBodiesMatch).isFalse();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentXml() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("<xml><a>a</a><b>b</b></xml>")
+                .withHeaderContentType("application/xml")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "<xml><b>b</b><a>a</a></xml>", request);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentCustomXml() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("<xml><a>a</a><b>b</b></xml>")
+                .withHeaderContentType("application/vnd.com+xml")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "<xml><b>b</b><a>a</a></xml>", request);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentCustomXmlCharset() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("<xml><a>a</a><b>b</b></xml>")
+                .withHeaderContentType("application/vnd.com+xml;charset=something")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "<xml><b>b</b><a>a</a></xml>", request);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenStringMatch() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("wibble")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "wibble", request);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesMatch_ShouldReturnFalse_WhenStringNotMatch() {
+        StubRequest request = new StubRequest.Builder()
+                .withPost("wibble")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, "wobble", request);
+
+        assertThat(isBodiesMatch).isFalse();
+    }
 }


### PR DESCRIPTION
As per [RFC7303](https://tools.ietf.org/html/rfc7303#page-11) and similar for [json](https://trac.tools.ietf.org/html/draft-ietf-appsawg-media-type-suffix-regs-02#section-3.1) this PR allows usage of headers such as

application/xml
application/xml;charset=UTF-8
application/vnd.com.whatever+xml
application/json
application/json;charset=UTF-8
application/vnd.com.whatever+json

to fall into the JSON and XML matching methods