### PR TITLE
Feature/stub description

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ This section explains the usage, intent and behavior of each property on the `re
 
 Here is a fully-populated, unrealistic endpoint:
 ```yaml
--  request:
+-  description: Optional description shown in logs
+   request:
       url: ^/your/awesome/endpoint$
       method: POST
       query:

--- a/integration/java/io/github/azagniotov/stubby4j/yaml/YAMLParserTest.java
+++ b/integration/java/io/github/azagniotov/stubby4j/yaml/YAMLParserTest.java
@@ -210,6 +210,23 @@ public class YAMLParserTest {
     }
 
     @Test
+    public void shouldUnmarshall_WhenYAMLValid_WithDescription() throws Exception {
+
+        final String url = "^/[a-z]{3}/[0-9]+/?$";
+        final String yaml = YAML_BUILDER.newStubbedRequest()
+                .withMethodGet()
+                .withUrl(url)
+                .withDescription("wobble")
+                .newStubbedResponse()
+                .withStatus("301").build();
+
+        final List<StubHttpLifecycle> loadedHttpCycles = unmarshall(yaml);
+        final StubHttpLifecycle actualHttpLifecycle = loadedHttpCycles.get(0);
+
+        assertThat(actualHttpLifecycle.getDescription()).isEqualTo("wobble");
+    }
+
+    @Test
     public void shouldUnmarshall_WhenYAMLValid_WithMultipleHTTPMethods() throws Exception {
 
         final String yaml = YAML_BUILDER.newStubbedRequest()

--- a/main/java/io/github/azagniotov/stubby4j/stubs/StubHttpLifecycle.java
+++ b/main/java/io/github/azagniotov/stubby4j/stubs/StubHttpLifecycle.java
@@ -25,18 +25,21 @@ public class StubHttpLifecycle implements ReflectableStub {
     private final Object response;
     private final String requestAsYAML;
     private final String responseAsYAML;
+    private final String description;
 
     private StubHttpLifecycle(
             final StubRequest request,
             final Object response,
             final String requestAsYAML,
             final String responseAsYAML,
-            final String completeYAML) {
+            final String completeYAML,
+            final String description) {
         this.request = request;
         this.response = response;
         this.requestAsYAML = requestAsYAML;
         this.responseAsYAML = responseAsYAML;
         this.completeYAML = completeYAML;
+        this.description = description;
     }
 
     public StubRequest getRequest() {
@@ -108,6 +111,10 @@ public class StubHttpLifecycle implements ReflectableStub {
         return request.getUrl();
     }
 
+    public String getDescription() {
+        return description;
+    }
+
     /**
      * Do not remove this method if your IDE complains that it is unused.
      * It is used by {@link ReflectionUtils} at runtime when fetching content for Ajax response
@@ -177,6 +184,7 @@ public class StubHttpLifecycle implements ReflectableStub {
         private String completeYAML;
         private String requestAsYAML;
         private String responseAsYAML;
+        private String description;
 
         public Builder() {
             this.request = null;
@@ -184,6 +192,7 @@ public class StubHttpLifecycle implements ReflectableStub {
             this.completeYAML = null;
             this.requestAsYAML = null;
             this.responseAsYAML = null;
+            this.description = null;
         }
 
         public Builder withRequest(final StubRequest request) {
@@ -226,14 +235,21 @@ public class StubHttpLifecycle implements ReflectableStub {
             return this;
         }
 
+        public Builder withDescription(final String description) {
+            this.description = description;
+
+            return this;
+        }
+
         public StubHttpLifecycle build() {
-            final StubHttpLifecycle stubHttpLifecycle = new StubHttpLifecycle(request, response, requestAsYAML, responseAsYAML, completeYAML);
+            final StubHttpLifecycle stubHttpLifecycle = new StubHttpLifecycle(request, response, requestAsYAML, responseAsYAML, completeYAML, description);
 
             this.request = null;
             this.response = okResponse();
             this.completeYAML = null;
             this.requestAsYAML = null;
             this.responseAsYAML = null;
+            this.description = null;
 
             return stubHttpLifecycle;
         }

--- a/main/java/io/github/azagniotov/stubby4j/stubs/StubRepository.java
+++ b/main/java/io/github/azagniotov/stubby4j/stubs/StubRepository.java
@@ -174,6 +174,7 @@ public class StubRepository {
         return Optional.empty();
     }
 
+    @CoberturaIgnore
     private static void logMatch(long elapsed, StubHttpLifecycle matched) {
         StringBuilder message = new StringBuilder()
                 .append("Found a match after ")

--- a/main/java/io/github/azagniotov/stubby4j/utils/ConsoleUtils.java
+++ b/main/java/io/github/azagniotov/stubby4j/utils/ConsoleUtils.java
@@ -21,6 +21,7 @@ package io.github.azagniotov.stubby4j.utils;
 
 import io.github.azagniotov.stubby4j.annotations.CoberturaIgnore;
 import io.github.azagniotov.stubby4j.cli.ANSITerminal;
+import io.github.azagniotov.stubby4j.stubs.StubHttpLifecycle;
 import io.github.azagniotov.stubby4j.stubs.StubRequest;
 import org.eclipse.jetty.http.HttpStatus;
 
@@ -29,6 +30,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
+
+import static io.github.azagniotov.stubby4j.utils.StringUtils.isSet;
 
 /**
  * @author Alexander Zagniotov
@@ -111,10 +114,18 @@ public final class ConsoleUtils {
     }
 
     @CoberturaIgnore
-    public static void logUnmarshalledStubRequest(final List<String> methods, final String url) {
-        final String loadedMsg = String.format("Loaded: %s %s", methods, url);
+    public static void logUnmarshalledStub(final StubHttpLifecycle lifecycle) {
+        final StubRequest request = lifecycle.getRequest();
 
-        ANSITerminal.loaded(loadedMsg);
+        final StringBuilder loadedMsgBuilder = new StringBuilder("Loaded: ");
+        loadedMsgBuilder.append(request.getMethod());
+        loadedMsgBuilder.append(" ");
+        loadedMsgBuilder.append(request.getUrl());
+        if (isSet(lifecycle.getDescription())) {
+            loadedMsgBuilder.append(String.format(" [%s]", lifecycle.getDescription()));
+        }
+
+        ANSITerminal.loaded(loadedMsgBuilder.toString());
     }
 
     @CoberturaIgnore

--- a/main/java/io/github/azagniotov/stubby4j/utils/ConsoleUtils.java
+++ b/main/java/io/github/azagniotov/stubby4j/utils/ConsoleUtils.java
@@ -117,10 +117,10 @@ public final class ConsoleUtils {
     public static void logUnmarshalledStub(final StubHttpLifecycle lifecycle) {
         final StubRequest request = lifecycle.getRequest();
 
-        final StringBuilder loadedMsgBuilder = new StringBuilder("Loaded: ");
-        loadedMsgBuilder.append(request.getMethod());
-        loadedMsgBuilder.append(" ");
-        loadedMsgBuilder.append(request.getUrl());
+        final StringBuilder loadedMsgBuilder = new StringBuilder("Loaded: ")
+                .append(request.getMethod())
+                .append(" ")
+                .append(request.getUrl());
         if (isSet(lifecycle.getDescription())) {
             loadedMsgBuilder.append(String.format(" [%s]", lifecycle.getDescription()));
         }

--- a/main/java/io/github/azagniotov/stubby4j/yaml/ConfigurableYAMLProperty.java
+++ b/main/java/io/github/azagniotov/stubby4j/yaml/ConfigurableYAMLProperty.java
@@ -20,7 +20,8 @@ public enum ConfigurableYAMLProperty {
     REQUEST,
     RESPONSE,
     STATUS,
-    URL;
+    URL,
+    DESCRIPTION;
 
     private static final Map<String, ConfigurableYAMLProperty> CACHE;
 

--- a/main/java/io/github/azagniotov/stubby4j/yaml/YAMLBuilder.java
+++ b/main/java/io/github/azagniotov/stubby4j/yaml/YAMLBuilder.java
@@ -22,6 +22,8 @@ public final class YAMLBuilder {
     private final static String REQUEST = String.format("-%s%s", TWO_SPACE, "request:");
     private final static String RESPONSE = String.format("%s%s", THREE_SPACE, "response:");
 
+    private final static String DESCRIPTION = String.format("%s%s", THREE_SPACE, "description: ");
+
     private final static String HEADERS = String.format("%s%s", SIX_SPACE, "headers:");
     private final static String SEQUENCE_RESPONSE_HEADERS = String.format("%s%s", NINE_SPACE, "headers: ");
 
@@ -225,6 +227,12 @@ public final class YAMLBuilder {
 
             final String tabbedKey = String.format("%s%s: ", NINE_SPACE, key);
             REQUEST_STRING_BUILDER.append(tabbedKey).append(value).append(NL);
+
+            return this;
+        }
+
+        public Request withDescription(final String value) {
+            REQUEST_STRING_BUILDER.append(NL).append(DESCRIPTION).append(value).append(NL);
 
             return this;
         }

--- a/unit/java/io/github/azagniotov/stubby4j/stubs/StubHttpLifecycleBuilderTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/stubs/StubHttpLifecycleBuilderTest.java
@@ -72,6 +72,13 @@ public class StubHttpLifecycleBuilderTest {
     }
 
     @Test
+    public void shouldReturnDescription_WhenDescription() {
+        final StubHttpLifecycle stubHttpLifecycle = httpCycleBuilder.withDescription("wibble").build();
+
+        assertThat(stubHttpLifecycle.getDescription()).isEqualTo("wibble");
+    }
+
+    @Test
     public void shouldThrow_WhenResponseObjectIsNotStubResponseType() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Trying to set response of the wrong type");

--- a/unit/java/io/github/azagniotov/stubby4j/yaml/YAMLBuilderTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/yaml/YAMLBuilderTest.java
@@ -5,9 +5,7 @@ import io.github.azagniotov.stubby4j.utils.FileUtils;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.github.azagniotov.stubby4j.stubs.StubbableAuthorizationType.BASIC;
-import static io.github.azagniotov.stubby4j.stubs.StubbableAuthorizationType.BEARER;
-import static io.github.azagniotov.stubby4j.stubs.StubbableAuthorizationType.CUSTOM;
+import static io.github.azagniotov.stubby4j.stubs.StubbableAuthorizationType.*;
 
 
 public class YAMLBuilderTest {
@@ -18,6 +16,8 @@ public class YAMLBuilderTest {
                 "-  request:" + FileUtils.BR +
                         "      method: [PUT]" + FileUtils.BR +
                         "      url: /invoice" + FileUtils.BR +
+                        "" + FileUtils.BR +
+                        "   description: Hello!" + FileUtils.BR +
                         "" + FileUtils.BR +
                         "   response:" + FileUtils.BR +
                         "      -  status: 200" + FileUtils.BR +
@@ -41,6 +41,7 @@ public class YAMLBuilderTest {
                 .newStubbedRequest()
                 .withMethodPut()
                 .withUrl("/invoice")
+                .withDescription("Hello!")
                 .newStubbedResponse()
                 .withSequenceResponseStatus("200")
                 .withSequenceResponseHeaders("content-type", Common.HEADER_APPLICATION_JSON)


### PR DESCRIPTION
Adds a new description field which can be used to show optional descriptions in the logs.  Useful when you have a number of stubs loaded for the same endpoint and it starts to get confusing as to which is being matched

```yaml
---
-  description: Stub one
   request:
      url: ^/one$
      method: GET

   response:
      status: 200
      latency: 100
      body: 'One!'

-  description: Stub two
   request:
      url: ^/two$
      method: GET

   response:
      status: 200
      latency: 100
      body: 'Two!'

-  request:
      url: ^/three$
      method: GET

   response:
      status: 200
      latency: 100
      body: 'Three!'
```

![image](https://user-images.githubusercontent.com/3418267/28794560-a3f0caea-762e-11e7-8165-d0d7554db0d4.png)
