### PR TITLE
Added support for UUID property and ability to delete/update stub by UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,260 @@
+#### 6.0.1-SNAPSHOT
+
+#### 6.0.0
+
+* Pull request #87 - Added support for UUID property & ability to get/delete/update stub by UUID (https://github.com/azagniotov)
+* Displaying UUID value in popup dialogs in Admin console when `[view]` YAML source button is clicked
+* Revisited HTTP response codes of Admin portal APIs that manage stubs (delete, get & update APIs)
+* Upgraded from Jetty `9.4.8.v20171121` to `9.4.9.v20180320`
+* Moved from `XMLUnit v1.x` to `XMLUnit v2.x` for a more optimized XML evaluation
+* Using `ehCache` for internal caching
+- Upon parsing of YAML config, Compiling regex patterns using different flag combinations: 
+  - `Pattern.MULTILINE`
+  - `Pattern.MULTILINE | Pattern.DOTALL`
+  - `Pattern.LITERAL` (as a fallback if any of the aforementioned compilations failed)
+
+#### 5.2.0
+* Pull request #91 - Added ability to use tokenized "Location" header in 3xx responses (https://github.com/dimadl)
+* Issue #92 - Added ability to honor stubbed 404 responses (https://github.com/MannanM)
+
+#### 5.1.1
+* Added ANSITerminal back. it is operational alongside the SLF4J for the cases when stubby is running as a standalone jar
+* Upgraded from Jetty `9.4.6.v20170531` to `9.4.8.v20171121`
+
+#### 5.1.0
+* Pull request #83 - ANSITerminal was replaced with SLF4J. It is up to the stuby4j consumer to choose their own logging implementation (https://github.com/asarkar)
+
+#### 5.0.2
+* Pull request #77 - New field `description` for stubs/features (https://github.com/goughy000)
+
+#### 5.0.1
+* Pull request #71 - Add endpoint to Delete all stubs (https://github.com/nningego)
+* Pull request #74 - Adding parsing tokens capabilities to the file body (https://github.com/OtavioRMachado)
+* Pull request #76 - Allow custom XML and JSON content types (https://github.com/goughy000)
+* Upgraded from Jetty `9.4.0.v20161208` to `9.4.6.v20170531`
+
+#### 5.0.0
+* 2017 release: a lot of internal maintenance such as code clean up, refactoring & improved test coverage
+* Supporting additional 3xx redirect HTTP codes when rendering redirect response: `303`, `307` & `308`
+
+#### 4.0.5
+* Pull request #63 - Dynamic token replacement is also applied to stubbed response headers
+* Upgraded from Jetty `9.3.13.v20161014` to `9.4.0.v20161208`
+* Added dependency on https://github.com/azagniotov/collection-type-safe-converter
+* 'Builder' sub-project got merged into the 'Main' sub-project
+
+#### 4.0.4
+* Upgraded from Jetty `9.3.12.v20160915` to `9.3.13.v20161014`
+* Shaved off stubby's start-up time due to parsing YAML config asynchronously
+* Issue #61 - During record & play, the stubbed query params were sent with recording request instead of the actual request query params
+
+#### 4.0.3
+* Optimized the stub matching algorithm by caching the previous matches [StubRepository#matchStub](https://github.com/azagniotov/stubby4j/blob/master/main/java/io/github/azagniotov/stubby4j/database/StubRepository.java)
+* Suppressed Jetty's default [ErrorHandler](http://download.eclipse.org/jetty/9.3.12.v20160915/apidocs/org/eclipse/jetty/server/handler/ErrorHandler.html) with a custom [JsonErrorHandler](main/java/io/github/azagniotov/stubby4j/handlers/JsonErrorHandler.java) to send errors in JSON format
+* Got rid off repackaged classes from Apache Commons in favor of Java 8 APIs
+* Using Java NIO for file operations
+
+#### 4.0.2
+* Log to terminal why a request fails to match https://github.com/soundcloud/stubby4j/commit/5901710efd31653a05804ebec62f67184c212832
+* Square brackets were not escaped as literals for regular expression in Json POST [BUG]
+* Pre-compiling & caching stubbed regex patterns upon parsing YAML stub configuration
+
+#### 4.0.1
+* Issue #54 - Support for regular expression in Json POST
+
+#### 4.0.0
+* Built using Java v1.8 (`1.8.0_60`)
+* Updated Gradle `build.gradle` to compile using Java v1.8
+* Upgraded from Jetty `9.2.10.v20150310` to `9.3.12.v20160915`
+* Updated Docker config
+* Renamed project root package from `by.stub` to `io.github.azagniotov.stubby4j`
+* Renamed Maven Central group ID from `by.stub` to `io.github.azagniotov`
+* Issue #55 - When running in `--debug`, dumping `HttpServletRequest` parameters, would implicitly call `ServletRequest#getInputStream()`
+* Issue #56 - Requests with query parameters values containing white spaces
+* Pull request #57 - `StubbyClient` starts Jetty with `-m` to mute the console logger, but it wasn't actually muted 
+
+#### 3.3.0
+* Allow callers to wait for the StubbyClient to finish (Oliver Weiler, https://github.com/helpermethod)
+* Serving response files from a local path constructed with regex tokens from the stubbed request (Radek Ostrowski, https://github.com/radek1st)
+
+#### 3.2.3
+* Dumping more debug information to the console if `--debug` option is on, also for successfully matched requests
+* Added support for `PUT` and `DELETE` methods in `StubbyClient` class
+
+#### 3.1.3
+* If POST'ed data type is `application/json`, the comparison of stubbed to posted data will be done using JSON entities with non-strict checking (content ordering wont matter, as long as it is the same)
+* If POST'ed data type is `application/xml`, the comparison of stubbed to posted data will be done using XML entities with non-strict checking (element & attribute ordering wont matter, as long as content is the same)
+
+#### 3.0.3
+* Added support for custom authorization type header with the help of the new `header` property `authorization-custom`
+* Fixed issue #43 (Live refresh in response sequence only for first response)
+
+#### 3.0.2
+* Added support for Bearer Token authorization with the help of the new `header` property `authorization-bearer`
+* Renamed existing `header` property `authorization` to `authorization-basic`
+* Some changes around the programmatic APIs in `StubbyClient` class due to the above changes
+* Respective changes in the current README due to the above changes
+
+#### 3.0.1
+* Upgraded Jetty to v9.2.10.v20150310
+* Added `--debug` option that dumps incoming raw HTTP request to the console
+* Added `--disable_admin_portal` option that does not configure Admin portal for stubby
+* Added `--disable_ssl` option that does not enable SSL for stubby
+* Added a new API to start stubby programmatically without specifying a YAML file `StubbyClient.startJettyYamless(...)`
+* Added a new `FaviconHandler` to handle requests for `favicon.ico` under the context root
+
+#### 3.0.0
+* Built using Java v1.7.0_76
+* Updated Jetty to v9.2.9.v20150224 (requires at least JRE v1.7.0_76: [Issue with Java v1.7.0_04](http://dev.eclipse.org/mhonarc/lists/jetty-users/msg05635.html))
+
+#### 2.0.22
+* Built using Java v1.7.0_04
+* Cleaned up project Gradle configuration 
+* Updated Gradle configuration to be compatible with Gradle v2.2.1 & Gradle Nexus plugin v2.3
+* Updated all (except Jetty) dependencies to their latest versions (as of May 10th, 2015)
+
+#### 2.0.21
+* Added console outputs for record & play functionality
+
+#### 2.0.20
+* Replacing all hardcoded `\n` with dynamically generated system line break characters
+
+#### 2.0.19
+* Record&Play is now more intelligent: when stubbed `request` is matched, its stubbed properties (`method`, `url`, `headers`, `post` and `query`) are used to construct HTTP request to the recordable destination URL provided in stubbed `response` body [ENHANCEMENT]
+* Added a workaround a limitation in SnakeYAML v1.13 used by stubby (it has limited JSON support, not all the JSON documents can be parsed) where it cannot parse escaped forward slashes in JSON [BUG]
+* Refreshing Admin status page was changing sequenced response counter ID [BUG]
+* Replaced hardcoded Unix new line character '\n' in YamlBuilderTest that caused the tests to fail on Windows [BUG]
+* Admin status page now shows what is the next sequenced response in the sequence queue [ENHANCEMENT]
+* Supporting HTTP requests with empty query params: `/uri?some_param=` or `/uri?some_param` [ENHANCEMENT]
+
+#### 2.0.18
+* When `--data` file was just a relative filename without parent directory, NPE was thrown when Admin portal status page was loaded [BUG]
+* Configured jetty GZIP handler for static resources and Stubs & Admin portals [ENHANCEMENT]
+* Added resource hit stats section to Admin portal status page [ENHANCEMENT]
+
+#### 2.0.17
+* Added a verification check in StubbyManager to make sure that Jetty has been started or shut down [ENHANCEMENT]
+* Upgraded SnakeYAML dependency library to v1.13 [ENHANCEMENT]
+* Admin status page: displaying YAML snippet for a given `request` or `response` separately instead of pairing them up [ENHANCEMENT]
+* Admin status page: displaying metadata of loaded external files (if any) [ENHANCEMENT]
+* Admin status page: displaying Ajax response in a JS popup, instead of injecting the Ajax response into HTML table [ENHANCEMENT]
+* A bunch of cosmetic changes on Admin status page [COSMETICS]
+
+#### 2.0.16
+* Displaying stubby JAR: version, its classpath location, built date, up-time, its input args and Java input args on status page [ENHANCEMENT]
+* Displaying stubby heap/non-heap memory usage on status page [ENHANCEMENT]
+* Added an option on admin status page to display YAML snippet for a given request & response pair [ENHANCEMENT]
+* Making sure that 'x-stubby-resource-id' header is always the first item in the stubbed headers on status page [ENHANCEMENT]
+* Changed colors of status page [COSMETICS]
+
+#### 2.0.15
+* When creating template token names for `query` or `headers` regex matches, the name format to be followed should be `headers.key_name.ID` or `query.key_name.ID` [ENHANCEMENT]
+
+#### 2.0.14
+* Whitespace was not allowed between the `<% ` & ` %>` and what's inside when specifying template tokens for dynamic token replacement in stubbed response [BUG]
+* Regex matches were stored against incorrect token names for `query` and `headers` regexes [BUG]
+* Renamed command line arg `--ssl` to `--tls` to reduce the confusion when having another command line arg that starts with letter `s`, like `--stubs` [ENHANCEMENT]
+* Added command line arg `--version` that prints current stubby4j version to the console [ENHANCEMENT]
+
+#### 2.0.13
+* Dynamic token replacement in stubbed response, by leveraging regex capturing groups as token values during HTTP request verification [FEATURE]
+
+#### 2.0.12
+* Removed flag `--watch_sleep_time`. The `--watch` flag can now accept an optional arg value which is the watch scan time in milliseconds. If milliseconds is not provided, the watch scans every 100ms [ENHANCEMENT]
+* Added additional API to start Jetty via StubbyClient by specifying an address to bind [ENHANCEMENT]
+
+#### 2.0.11
+* `--watch` flag sleep time is now configurable via `--watch_sleep_time` and defaults to `100ms` if `--watch_sleep_time` is not provided [ENHANCEMENT]
+* Added a `GET` endpoint on Admin portal `localhost:8889/refresh` for refreshing stubbed data [ENHANCEMENT]
+
+#### 2.0.10
+* Record & Replay. The HTTP traffic is recorded on the first call to stubbed `uri` and subsequent calls will play back the recorded HTTP response, without actually connecting to the external server [FEATURE]
+
+#### 2.0.9
+* Ensuring that Admin portal status page loads fast by not rendering stubbed response content which slows down page load. User can invoke Ajax request to fetch the desired response content as needed [ENHANCEMENT]
+* Pre-setting header `x-stubby-resource-id` during YAML parse time, instead of on demand. This way resource IDs are viewable on Admin status page [ENHANCEMENT]
+* Making sure that header `x-stubby-resource-id` is recalculated accordingly after stubbed data in memory has changed (due to reset, or deletion etc.) [BUG]
+* Added date stamp to live reload success message [COSMETICS]
+
+#### 2.0.8
+* Making sure that every stubbed response returned to the client contains its resource ID in the header `x-stubby-resource-id`. The latter is useful if the returned resource needs to be updated at run time by ID via Admin portal [FEATURE]
+
+#### 2.0.7
+* Force regex matching only everywhere (url, query, post, headers, etc.) to avoid confusion and unexpected behaviour, with default fallback to simple full-string match (Michael England) [ENHANCEMENT]
+
+#### 2.0.6
+* Live YAML scan now also check for modifications to external files referenced from main YAML [ENHANCEMENT]
+* YAML parsing logic revisited [COSMETICS]
+* Code cleanup [COSMETICS]
+
+#### 2.0.5
+* Added ability to specify sequence of responses on the same URI using `file` (Prakash Kandavel) [ENHANCEMENT]
+* Minor code clean up [COSMETICS]
+* Documentation update [COSMETICS]
+
+#### 2.0.4
+* Making sure that operations starting up stubby and managing stubbed data are atomic  [ENHANCEMENT]
+
+#### 2.0.3
+* Typo in test was giving wrong indication that when `file` not set, stubbed response fallsback to `body` [BUG]
+* Eliminated implicit test to test dependencies in AdminPortalTest that was causing issues when running the tests under JDK 1.7 [BUG]
+* Added convenience method in StubbyClient `updateStubbedData` [ENHANCEMENT]
+
+#### 2.0.2
+* Stubbed request HTTP header names were not lower-cased at the time of match [BUG]
+* Doing GET on Admin portal `/` will display all loaded stub data in a YAML format in the browser [FEATURE]
+* Doing GET on Admin portal `/<id>` will display loaded stub data matched by provided index in a YAML format in the browser [FEATURE]
+* Doing DELETE on Admin portal `/<id>` will delete stubbed request from the list of loaded stub requests using the index provided [FEATURE]
+* Doing PUT on Admin portal `/<id>` will update stubbed request in the list of loaded stub requests using the index provided [FEATURE]
+* When YAML is parsed, if `file` could not be loaded, the IOException is not thrown anymore. Instead a warning recorded in the terminal [ENHANCEMENT]
+* When could not match submitted HTTP request to stubbed requests, the not found message is much more descriptive [ENHANCEMENT]
+* URI for registering new stub data programmatically via POST on Admin portal was changed from `/stubdata/new` to `/` [COSMETICS]
+* URI for getting loaded stub data status was changed from `/ping` to `/status` on Admin portal [COSMETICS]
+* Updated to SnakeYAML v1.12 [COSMETICS]
+* Updated default response message when response content could not be loaded from `file` [ENHANCEMENT]
+* Documentation refinement [COSMETICS]
+
+#### 2.0.1
+* Every ```url``` is treated as a regular expression now [ENHANCEMENT]
+* ANSI logging in the terminal was working only for HTTP requests with status 200 [BUG]
+* Documentation refinement [COSMETICS]
+
+#### 2.0.0
+* Mainly backend code improvements: A lot of refactoring for better code readability, expanding test coverage [COSMETICS]
+
+#### 1.0.63
+* Added ability to specify sequence of stub responses for the same URI, that are sent to the client in the loop [FEATURE]
+* Configuration scan was not enabled, even if the ```--watch``` command line argument was passed [BUG]
+
+#### 1.0.62
+* Added ability to specify regex in stabbed URL for dynamic matching [FEATURE]
+* A lot of minor fixes, refactorings and code cleaned up [COSMETICS]
+* Documentation revisited and rewritten into a much clearer format [ENHANCEMENT]
+
+#### 1.0.61
+* Just some changes around unit, integration and functional tests. Code cleanup [COSMETICS]
+
+#### 1.0.60
+* stubby's admin page was generating broken hyper links if URL had single quotes [BUG]
+* stubby is able to match URL when query string param was an array with elements within single quotes, ie: ```attributes=['id','uuid']``` [ENHANCEMENT]
+
+#### 1.0.59
+* stubby's admin page was not able to display the contents of stubbed response/request ```body```, ```post``` or ```file``` [BUG]
+* stubby was not able to match URL when query string param was an array with quoted elements, ie: ```attributes=["id","uuid","created","lastUpdated","displayName","email"]``` [BUG]
+
+#### 1.0.58
+* Making sure that stubby can serve binary files as well as ascii files, when response is loaded using the ```file``` property [ENHANCEMENT]
+
+#### 1.0.57
+* Migrated the project from Maven to Gradle (thanks to [Logan McGrath](https://github.com/lmcgrath) for his feedback and assistance). The project has now a multi-module setup [ENHANCEMENT]
+
+#### 1.0.56
+* If `request.post` was left out of the configuration, stubby would ONLY match requests without a post body to it [BUG]
+* Fixing `See Also` section of readme [COSMETICS]
+
+#### 1.0.55
+* Updated YAML example documentation [COSMETICS]
+* Bug fix where command line options `mute`, `debug` and `watch` were overlooked [BUG]
+
+#### 1.0.54
+* Previous commit (`v1.0.53`) unintentionally broke use of embedded stubby [BUG]

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 
 A highly flexible and configurable tool for testing interactions of SOA applications with web services (REST, SOAP, WSDL etc.) over HTTP(S) protocol. It is an actual HTTP server (stubby4j uses embedded Jetty) that allows stubbing of external systems with ease for integration, contract & behavior testing. Please refer to [Key features](#key-features) for more information
 
-##### Why the word "stubby"?
+#### Why the word "stubby"?
 It is a stub HTTP server after all, hence the "stubby". Also, in Australian slang "stubby" means _beer bottle_
 
-## User manual for stubby4j v5.2.0
+## User manual for stubby4j v6.0.0
 ### Table of contents
 
 * [Quick start example](#quick-start-example)
@@ -28,7 +28,7 @@ It is a stub HTTP server after all, hence the "stubby". Also, in Australian slan
    * [Installing stubby4j to local .m2 repository](#installing-stubby4j-to-local-m2-repository)
 * [Command-line switches](#command-line-switches)
 * [Endpoint configuration HOWTO](#endpoint-configuration-howto)
-   * [Stub/Feature Description](#stubfeature-description)
+   * [Stub/Feature](#stubfeature)
    * [Request](#request)
       * [Regex stubbing for dynamic matching](#regex-stubbing-for-dynamic-matching)
       * [Authorization Header](#authorization-header)
@@ -36,7 +36,7 @@ It is a stub HTTP server after all, hence the "stubby". Also, in Australian slan
       * [Dynamic token replacement in stubbed response](#dynamic-token-replacement-in-stubbed-response)
       * [Record and Play](#record-and-play)
 * [Performance optimization index](#performance-optimization-index)
-   * [Regex pattern precompilation](#regex-pattern-precompilation)
+   * [Regex pattern precompilation](#regex-pattern-pre-compilation)
    * [Local caching of returning matched requests](#local-caching-of-returning-matched-requests)
 * [The admin portal](#the-admin-portal)
    * [Supplying endpoints to stubby](#supplying-endpoints-to-stubby)
@@ -60,14 +60,14 @@ It is a stub HTTP server after all, hence the "stubby". Also, in Australian slan
 
 This section explains how to get stubby4j up and running using a very simple example "Hello, World", without building stubby4j from source locally using Gradle. 
 
-##### Minimum system requirements to run stubby4j archives hosted on [Maven Central][maven-link]
+#### Minimum system requirements to run stubby4j archives hosted on [Maven Central][maven-link]
 
 * version >= 4.0.0:  Oracle JRE v1.8.0_60
 * version >= 3.0.0:  Oracle JRE v1.7.0_76
 * version = 2.0.22: Oracle JRE v1.7.0_04
 * version < 2.0.22: Oracle JRE 1.6.0_65-b14-462
 
-##### Setup
+#### Setup
 
 * Download the [latest stubby4j version][maven-link] (the JAR archive).
 * Create the following local YAML file: 
@@ -139,15 +139,14 @@ Run `gradle cobertura` command to:
 
 ## Third-party dependencies
 
-* __javax.servlet-api-3.1.0.jar__
-* jetty-server-9.4.8.v20171121.jar
-* jetty-servlets-9.4.8.v20171121.jar
-* commons-cli-1.2.jar
-* snakeyaml-1.17.jar
-* jsonassert-1.3.0.jar
-* xmlunit-1.6.jar
-* json-20090211.jar
-* slf4j-api:1.7.25.jar
+* __javax.servlet-api:3.1.0__
+* jetty-server:9.4.9.v20180320
+* jetty-servlets:9.4.9.v20180320
+* commons-cli:1.2
+* snakeyaml:1.20
+* jsonassert:1.3.0
+* xmlunit-legacy:2.5.1
+* slf4j-api:1.7.25
 
 
 ## Adding stubby4j to your project
@@ -159,22 +158,22 @@ The following are the stubby4j artifacts that are hosted on [Maven Central][mave
 * `stubby4j-x.x.x-sources.jar`
 * `stubby4j-x.x.x-javadoc.jar`
 
-##### Gradle
+#### Gradle
 ```xml
-compile("io.github.azagniotov:stubby4j:5.2.0")
+compile("io.github.azagniotov:stubby4j:6.0.0")
 ```
 or by adding a `classifier` to the JAR name like `no-dependencies` or `no-jetty`, i.e.:
 
 ```xml
-compile("io.github.azagniotov:stubby4j:5.2.0:no-jetty")
+compile("io.github.azagniotov:stubby4j:6.0.0:no-jetty")
 ```
 
-##### Maven
+#### Maven
 ```xml
 <dependency>
     <groupId>io.github.azagniotov</groupId>
     <artifactId>stubby4j</artifactId>
-    <version>5.2.0</version>
+    <version>6.0.0</version>
 </dependency>
 ```
 or by adding a `classifier` to the JAR name like `no-dependencies` or `no-jetty`, i.e.:
@@ -183,7 +182,7 @@ or by adding a `classifier` to the JAR name like `no-dependencies` or `no-jetty`
 <dependency>
     <groupId>io.github.azagniotov</groupId>
     <artifactId>stubby4j</artifactId>
-    <version>5.2.0</version>
+    <version>6.0.0</version>
     <classifier>no-dependencies</classifier>
 </dependency>
 ```
@@ -192,17 +191,17 @@ or by adding a `classifier` to the JAR name like `no-dependencies` or `no-jetty`
 
 Run `gradle install` command to:
 
-* Install `stubby4j-5.2.1-SNAPSHOT*.jar` to local `~/.m2/repository`
+* Install `stubby4j-6.0.1-SNAPSHOT*.jar` to local `~/.m2/repository`
 * All the artifacts will be installed under `~/.m2/repository/{groupId}/{artifactId}/{version}/`, e.g.: `~/.m2/repository/io/github/azagniotov/stubby4j/5.2.1-SNAPSHOT/`
 
 Now you can include locally installed stubby4j `SNAPSHOT` artifacts in your project:
 ```xml
-compile("io.github.azagniotov:stubby4j:5.2.1-SNAPSHOT")
+compile("io.github.azagniotov:stubby4j:6.0.1-SNAPSHOT")
 ```
 or by adding a `classifier` to the JAR name like `no-dependencie`s or `no-jetty`, i.e.:
 
 ```xml
-compile("io.github.azagniotov:stubby4j:5.2.1-SNAPSHOT:no-jetty")
+compile("io.github.azagniotov:stubby4j:6.0.1-SNAPSHOT:no-jetty")
 ```
 
 
@@ -246,6 +245,7 @@ This section explains the usage, intent and behavior of each property on the `re
 Here is a fully-populated, unrealistic endpoint:
 ```yaml
 -  description: Optional description shown in logs
+   uuid: fdkfsd8f8ds7f
    request:
       url: ^/your/awesome/endpoint$
       method: POST
@@ -274,9 +274,9 @@ Here is a fully-populated, unrealistic endpoint:
       file: responseData.xml
 ```
 
-## Stub/Feature Description
+## Stub/Feature
 
-##### description (optional)
+#### description (optional)
 
 * Description field which can be used to show optional descriptions in the logs
 * Useful when you have a number of stubs loaded for the same endpoint and it starts to get confusing as to which is being matched
@@ -312,11 +312,30 @@ Here is a fully-populated, unrealistic endpoint:
       body: 'Three!'
 ```
 
+#### uuid (optional)
+
+* Useful when you want to specify unique identifier so it would be easier to update/delete it at runtime
+
+```yaml
+-  uuid: 9136d8b7-f7a7-478d-97a5-53292484aaf6
+   request:
+      method: GET
+      url: /with/configured/uuid/property
+
+   response:
+      headers:
+         content-type: application/json
+      status: 200
+      body: >
+         {"status" : "OK"}
+```
+
+
 ## Request
 
 This object is used to match an incoming request to stubby against the available endpoints that have been configured.
 
-##### url (required)
+#### url (required)
 
 * is a full-fledged __regular expression__
 * This is the only required property of an endpoint.
@@ -354,7 +373,7 @@ A demonstration using regular expressions:
       url: ^/[a-z]{3}-[a-z]{3}/[0-9]{2}/[A-Z]{2}/[a-z0-9]+$
 ```
 
-##### method
+#### method
 
 * defaults to `GET`.
 * case-insensitive.
@@ -387,7 +406,7 @@ A demonstration using regular expressions:
          -  HEAD
 ```
 
-##### query
+#### query
 
 * can be a full-fledged __regular expression__
 * if not stubbed, stubby ignores query parameters on incoming request and will match only request URL
@@ -468,7 +487,7 @@ A demonstration using regular expressions:
          term: "['stalin and truman']"
 ```
 
-##### post
+#### post
 
 * Represents the body POST of incoming request, ie.: form data
 * can be a full-fledged __regular expression__
@@ -527,7 +546,7 @@ A demonstration using regular expressions:
          {"internalKey": "<%post.1%>"}
 ```
 
-##### file
+#### file
 
 * holds a path to a local file (it can be an `absolute` or `relative` path to the main YAML specified in `-d` or `--data`). This property allows you to split up stubby data across multiple files instead of making one huge bloated main config YAML. For example, let's say you want to stub a big POST payload, so instead of dumping a lot of text under the `post` property, you could specify a local file with the payload using the `file` property:
 
@@ -558,7 +577,7 @@ postedData.json
 
 * if `postedData.json` doesn't exist on the filesystem when `/match/against/file` is matched in incoming request, stubby will match post contents against `{"fallback":"data"}` (from `post`) instead.
 
-##### headers
+#### headers
 
 * can be a full-fledged __regular expression__
 * if not stubbed, stubby ignores headers on incoming request and will match only request URL
@@ -709,7 +728,7 @@ Assuming a match has been made against the given `request` object, data from `re
          body: Still going strong!
 ```
 
-##### status
+#### status
 
 * the HTTP status code of the response.
 * integer or integer-like string.
@@ -723,7 +742,7 @@ Assuming a match has been made against the given `request` object, data from `re
       status: 420
 ```
 
-##### body
+#### body
 
 * contents of the response body
 * defaults to an empty content body
@@ -772,7 +791,7 @@ Assuming a match has been made against the given `request` object, data from `re
       body: https://api.twitter.com/1.1/direct_messages.json?since_id=240136858829479935&count=1
 ```
 
-##### file
+#### file
 
 * similar to `request.file`, holds a path to a local file (it can be an `absolute` or `relative` path to the main YAML specified in `-d` or `--data`). This property allows you to split up stubby data across multiple files instead of making one huge bloated main config YAML. For example, let's say you want to render a large response body upon successful stub matching, so instead of dumping a lot of text under the `body` property, you could specify a local file with the response content using the `file` property (btw, the `file` can also refer to binary files):
 
@@ -798,7 +817,7 @@ response:
       file: extremelyLongJsonFile.json
 ```
 
-##### headers
+#### headers
 
 * similar to `request.headers` except that these are sent back to the client.
 * by default, header `x-stubby-resource-id` containing resource ID is returned with each stubbed response. The ID is useful if the returned resource needs to be updated at run time by ID via Admin portal
@@ -819,7 +838,7 @@ response:
          }]
 ```
 
-##### latency
+#### latency
 
 * time to wait, in milliseconds, before sending back the response
 * good for testing timeouts, or slow connections
@@ -841,7 +860,7 @@ stubby supports dynamic token replacement on the following properties:
 - `response` `header` name values (including `location` header value)
 - `response` `file` names & payloads.
 
-##### Example
+#### Example
 ```yaml
 -  request:
       method: [GET]
@@ -876,35 +895,35 @@ stubby supports dynamic token replacement on the following properties:
       status: 200
       body: Returned invoice number# <% url.1 %> in category '<% url.2 %>' on the date '<% query.date.1 %>', using header custom-header <% headers.custom-header.0 %>
 ```
-##### Example explained
+#### Example explained
 
 The `url` regex `^/account/(\d{5})/category/([a-zA-Z]+)` has two defined capturing groups: `(\d{5})` and `([a-zA-Z]+)`, `query` regex has one defined capturing group `([a-zA-Z]+)`. In other words, a manually defined capturing group has parenthesis around it.
 
 Although, the `headers` regex does not have capturing groups defined explicitly (no regex sections within parenthesis), its matched value is still accessible in a template (keep on reading!).
 
-##### Token structure
+#### Token structure
 The tokens in `response` `body` follow the format of `<%` `PROPERTY_NAME` `.` `CAPTURING_GROUP_ID` `%>`. If it is a token that should correspond to `headers` or `query` regex match, then the token structure would be as follows: `<%` `HEADERS_OR_QUERY` `.` `KEY_NAME` `.` `CAPTURING_GROUP_ID` `%>`. Whitespace is __allowed__ between the `<%` & `%>` and what's inside.
 
-##### Numbering the tokens based on capturing groups without sub-groups
+#### Numbering the tokens based on capturing groups without sub-groups
 When giving tokens their ID based on the count of manually defined capturing groups within regex, you should start from `1`, not zero (zero reserved for token that holds __full__ regex match) from left to right. So the leftmost capturing group would be `1` and the next one to the right of it would be `2`, etc.
 
 In other words `<% url.1 %>` and `<% url.2 %>` tokens correspond to two capturing groups from the `url` regex `(\d{5})` and `([a-zA-Z]+)`, while `<% query.date.1 %>` token corresponds to one capturing group `([a-zA-Z]+)` from the `query` `date` property regex.
 
-##### Numbering the tokens based on capturing groups with sub-groups
+#### Numbering the tokens based on capturing groups with sub-groups
 In regex world, capturing groups can contain capturing sub-groups, as an example consider proposed `url` regex: `^/resource/` `(` `([a-z]{3})` `-` `([0-9]{3})` `)` `$`. In the latter example, the regex has three groups - a parent group `([a-z]{3}-[0-9]{3})` and two sub-groups within: `([a-z]{3})` & `([0-9]{3})`.
 
 When giving tokens their ID based on the count of capturing groups, you should start from `1`, not zero (zero reserved for token that holds __full__ regex match) from left to right. If a group has sub-group within, you count the sub-group(s) first (also from left to right) before counting the next one to the right of the parent group.
 
 In other words tokens `<% url.1 %>`, `<% url.2 %>` and `<% url.3 %>` correspond to the three capturing groups from the `url` regex (starting from left to right): `([a-z]{3}-[0-9]{3})`, `([a-z]{3})` and `([0-9]{3})`.
 
-##### Tokens with ID zero
+#### Tokens with ID zero
 Tokens with ID zero can obtain __full__ match value from the regex they reference. In other words, tokens with ID zero do not care whether regex has capturing groups defined or not. For example, token `<% url.0 %>` will be replaced with the `url` __full__ regex match from `^/account/(\d{5})/category/([a-zA-Z]+)`. So if you want to access the `url` __full__ regex match, respectively you would use token `<% url.0 %>` in your template.
 
 Another example, would be the earlier case where `headers` `custom-header` property regex does not have capturing groups defined within. Which is fine, since the `<% headers.custom-header.0 %>` token corresponds to the __full__ regex match in the `header` `custom-header` property regex: `[0-9]+`.
 
 It is also worth to mention, that the __full__ regex match value replacing token `<% query.date.0 %>`, would be equal to the regex capturing group value replacing `<% query.date.1 %>`. This is due to how the `query` `date` property regex is defined - the one and only capturing group in the `query` `date` regex, is also the __full__ regex itself.
 
-##### Where to specify the template
+#### Where to specify the template
 You can specify template with tokens in both `body` as a string or using `file` by specifying template as external local file. When template is specified as `file`, the contents of local file from `file` will be replaced.
 
 Alternatively, you can also template the path to the file itself:
@@ -937,10 +956,10 @@ When the request is recieved and the regex matches, the path to the file will ge
 ```
 Another example demonstrating the usage of tokens from the matched regex groups
 
-##### When token interpolation happens
+#### When token interpolation happens
 After successful HTTP request verification, if your `body` or contents of local file from `file` contain tokens - the tokens will be replaced just before rendering HTTP response.
 
-##### Troubleshooting
+#### Troubleshooting
 * Make sure that the regex you used in your stubby4j configuration actually does what it suppose to do. Validate that it works before using it in stubby4j
 * Make sure that the regex has capturing groups for the parts of regex you want to capture as token values. In other words, make sure that you did not forget the parenthesis within your regex if your token IDs start from `1`
 * Make sure that you are using token ID zero, when wanting to use __full__ regex match as the token value
@@ -952,7 +971,7 @@ After successful HTTP request verification, if your `body` or contents of local 
 If `body` of the stubbed `response` contains a URL starting with http(s), stubby knows that it should record an HTTP response
 from the provided URL (before rendering the stubbed response) and replay the recorded HTTP response on each subsequent call.
 
-##### Example
+#### Example
 ```yaml
 -  request:
       method: [GET]
@@ -967,7 +986,7 @@ from the provided URL (before rendering the stubbed response) and replay the rec
          content-type: application/json
       body: http://maps.googleapis.com
 ```
-##### Example explained
+#### Example explained
 
 Upon successful HTTP request verification, properties of stubbed `request` (`method`, `url`, `headers`, `post` and `query`) are used to construct
 an HTTP request to the destination URL specified in `body` of the stubbed `response`.
@@ -975,7 +994,7 @@ an HTTP request to the destination URL specified in `body` of the stubbed `respo
 In the above example, stubby will record HTTP response received after submitting an HTTP GET request to the url below:
 `http://maps.googleapis.com/maps/api/geocode/json?sensor=false&address=1600+Amphitheatre+Parkway,+Mountain+View,+CA`
 
-##### Please note
+#### Please note
 * Recorded HTTP response is not persistable, but kept in memory only. In other words, upon stubby shutdown the recording is lost
 * Make sure to specify in `response` `body` only the URL, without the path info. Path info should be specified in `request` `url`
 
@@ -1004,11 +1023,18 @@ loaded in memory. If a full match was found, then that match will be cached usin
 
 The admin portal is a RESTful(ish) endpoint running on `localhost:8889`. Or wherever you described through stubby's command line args.
 
-##### Supplying endpoints to stubby
+
+#### The status page
+
+You can view the currently configured endpoints by going to `localhost:8889/status`
+
+
+#### Supplying endpoints to stubby
 
 Submit `POST` requests to `localhost:8889` at runtime __OR__ load a data-file (using non-optional `-d` / `--data` flags) with the following structure for each endpoint:
 
 * `description`: optional description shown in logs
+* `uuid`: optional unique identifier
 * `request`: describes the client's call to the server
    * `method`: GET/POST/PUT/DELETE/etc.
    * `url`: the URI regex string. GET parameters should also be included inline here
@@ -1023,8 +1049,46 @@ Submit `POST` requests to `localhost:8889` at runtime __OR__ load a data-file (u
    * `body`: the textual body of the server's response to the client
    * `status`: the numerical HTTP status code (200 for OK, 404 for NOT FOUND, etc.)
 
+#### Getting the current list of stubbed endpoints
 
-##### YAML (file only or POST/PUT)
+Performing a `GET` request on `localhost:8889` will return a YAML list of all currently saved responses. It will reply with `204 : No Content` if there are none saved.
+Performing a `GET` request on `localhost:8889/<id>` will return the YAML object representing the response with the supplied id.
+
+#### Refreshing stubbed data via an endpoint
+
+If for some reason you do not want/cannot/not able to use `--watch` flag when starting stubby4j (or cannot restart stubby),
+you can submit `GET` request to `localhost:8889/refresh` (or load it in a browser) in order to refresh the stubbed data.
+
+#### Updating existing endpoints
+
+Stubs can be updated by either `(a)` stub ID or `(b)` unique identifier (See [Stub/Feature UUID](#uuid-optional)).
+
+The specific stub ID (`resource-id-<id>`) can be found when viewing stubs at `localhost:8889/status`. 
+
+Updating stubs by stub ID can get rather brittle when dealing with big YAML configs or working with shared stubs. Therefore it is better to configure `uuid` property 
+per stub in order to make stub management easier & isolated. 
+
+* Send a `PUT` request with a stub payload to `localhost:8889/<id>`. It will reply with `400 Bad Request` if id does not exist. Success `201 Created`
+* Send a `PUT` request with a stub payload to `localhost:8889/configured-uuid`. It will reply with `400 Bad Request` if uuid does not exist. Success `201 Created` 
+
+#### Deleting endpoints
+
+Stubs can be deleted by either `(a)` stub ID or `(b)` unique identifier (See [Stub/Feature UUID](#uuid-optional)).
+
+The specific stub ID (`resource-id-<id>`) can be found when viewing stubs at `localhost:8889/status`. 
+
+Deleting stubs by stub ID can get rather brittle when dealing with big YAML configs or working with shared stubs. Therefore it is better to configure `uuid` property 
+per stub in order to make stub management easier & isolated. 
+
+* Send a `DELETE` request to `localhost:8889/<id>`. It will reply with `400 Bad Request` if id does not exist. Success `200 OK`
+* Send a `DELETE` request to `localhost:8889/configured-uuid`. It will reply with `400 Bad Request` if uuid does not exist. Success `200 OK`
+
+#### Deleting ALL endpoints at once
+
+Send a `DELETE` request to `localhost:8889`
+
+
+#### YAML (file only or POST/PUT)
 ```yaml
 -  description: "this is a feature describing something"
    request:
@@ -1082,10 +1146,11 @@ Submit `POST` requests to `localhost:8889` at runtime __OR__ load a data-file (u
       status: 304
 ```
 
-##### JSON support
+#### JSON support
+
 JSON is a subset of YAML 1.2, SnakeYAML (Third-party library used by stubby4j for YAML & JSON parsing) implements YAML 1.1 at the moment. It means that not all the JSON documents can be parsed. Just give it a go.
 
-###### JSON (file or POST/PUT)
+#### JSON (file or POST/PUT)
 
 ```json
 [
@@ -1150,39 +1215,12 @@ JSON is a subset of YAML 1.2, SnakeYAML (Third-party library used by stubby4j fo
 
 If you want to load more than one endpoint via file, use either a JSON array or YAML list (-) syntax. When creating or updating one stubbed request, the response will contain `Location` in the header with the newly created resources' location
 
-##### Getting the current list of stubbed endpoints
-
-Performing a `GET` request on `localhost:8889` will return a YAML list of all currently saved responses. It will reply with `204 : No Content` if there are none saved.
-
-Performing a `GET` request on `localhost:8889/<id>` will return the YAML object representing the response with the supplied id.
-
-##### The status page
-
-You can also view the currently configured endpoints by going to `localhost:8889/status`
-
-##### Refreshing stubbed data via an endpoint
-
-If for some reason you do not want/cannot/not able to use `--watch` flag when starting stubby4j (or cannot restart stubby),
-you can submit `GET` request to `localhost:8889/refresh` (or load it in a browser) in order to refresh the stubbed data.
-
-##### Updating existing endpoints
-
-Perform `PUT` requests in the same format as using `POST`, only this time supply the id in the path. For instance, to update the response with id 4 you would `PUT` to `localhost:8889/4`.
-
-##### Deleting endpoints
-
-Send a `DELETE` request to `localhost:8889/<id>`
-
-##### Deleting ALL endpoints at once
-
-Send a `DELETE` request to `localhost:8889`
-
 
 ## The stubs portal
 
 Requests sent to any url at `localhost:8882` (or wherever you told stubby to run) will search through the available endpoints and, if a match is found, respond with that endpoint's `response` data
 
-##### How endpoints are matched
+#### How endpoints are matched
 
 For a given endpoint, stubby only cares about matching the properties of the request that have been defined in the YAML. The exception to this rule is `method`; if it is omitted it is defaulted to `GET`.
 
@@ -1224,259 +1262,13 @@ You can start-up and manage stubby4j with the help of [StubbyClient](main/java/i
 
 ## Change log
 
-##### 5.2.1-SNAPSHOT
+See CHANGELOG for details
 
-##### 5.2.0
-* Pull request #91 - Added ability to use tokenized "Location" header in 3xx responses (https://github.com/dimadl)
-* Issue #92 - Added ability to honor stubbed 404 responses (https://github.com/MannanM)
-
-##### 5.1.1
-* Added ANSITerminal back. it is operational alongside the SLF4J for the cases when stubby is running as a standalone jar
-* Upgraded from Jetty `9.4.6.v20170531` to `9.4.8.v20171121`
-
-##### 5.1.0
-* Pull request #83 - ANSITerminal was replaced with SLF4J. It is up to the stuby4j consumer to choose their own logging implementation (https://github.com/asarkar)
-
-##### 5.0.2
-* Pull request #77 - New field `description` for stubs/features (https://github.com/goughy000)
-
-##### 5.0.1
-* Pull request #71 - Add endpoint to Delete all stubs (https://github.com/nningego)
-* Pull request #74 - Adding parsing tokens capabilities to the file body (https://github.com/OtavioRMachado)
-* Pull request #76 - Allow custom XML and JSON content types (https://github.com/goughy000)
-* Upgraded from Jetty `9.4.0.v20161208` to `9.4.6.v20170531`
-
-##### 5.0.0
-* 2017 release: a lot of internal maintenance such as code clean up, refactoring & improved test coverage
-* Supporting additional 3xx redirect HTTP codes when rendering redirect response: `303`, `307` & `308`
-
-##### 4.0.5
-* Pull request #63 - Dynamic token replacement is also applied to stubbed response headers
-* Upgraded from Jetty `9.3.13.v20161014` to `9.4.0.v20161208`
-* Added dependency on https://github.com/azagniotov/collection-type-safe-converter
-* 'Builder' sub-project got merged into the 'Main' sub-project
-
-##### 4.0.4
-* Upgraded from Jetty `9.3.12.v20160915` to `9.3.13.v20161014`
-* Shaved off stubby's start-up time due to parsing YAML config asynchronously
-* Issue #61 - During record & play, the stubbed query params were sent with recording request instead of the actual request query params
-
-##### 4.0.3
-* Optimized the stub matching algorithm by caching the previous matches [StubRepository#matchStub](https://github.com/azagniotov/stubby4j/blob/master/main/java/io/github/azagniotov/stubby4j/database/StubRepository.java)
-* Suppressed Jetty's default [ErrorHandler](http://download.eclipse.org/jetty/9.3.12.v20160915/apidocs/org/eclipse/jetty/server/handler/ErrorHandler.html) with a custom [JsonErrorHandler](main/java/io/github/azagniotov/stubby4j/handlers/JsonErrorHandler.java) to send errors in JSON format
-* Got rid off repackaged classes from Apache Commons in favor of Java 8 APIs
-* Using Java NIO for file operations
-
-##### 4.0.2
-* Log to terminal why a request fails to match https://github.com/soundcloud/stubby4j/commit/5901710efd31653a05804ebec62f67184c212832
-* Square brackets were not escaped as literals for regular expression in Json POST [BUG]
-* Pre-compiling & caching stubbed regex patterns upon parsing YAML stub configuration
-
-##### 4.0.1
-* Issue #54 - Support for regular expression in Json POST
-
-##### 4.0.0
-* Built using Java v1.8 (`1.8.0_60`)
-* Updated Gradle `build.gradle` to compile using Java v1.8
-* Upgraded from Jetty `9.2.10.v20150310` to `9.3.12.v20160915`
-* Updated Docker config
-* Renamed project root package from `by.stub` to `io.github.azagniotov.stubby4j`
-* Renamed Maven Central group ID from `by.stub` to `io.github.azagniotov`
-* Issue #55 - When running in `--debug`, dumping `HttpServletRequest` parameters, would implicitly call `ServletRequest#getInputStream()`
-* Issue #56 - Requests with query parameters values containing white spaces
-* Pull request #57 - `StubbyClient` starts Jetty with `-m` to mute the console logger, but it wasn't actually muted 
-
-##### 3.3.0
-* Allow callers to wait for the StubbyClient to finish (Oliver Weiler, https://github.com/helpermethod)
-* Serving response files from a local path constructed with regex tokens from the stubbed request (Radek Ostrowski, https://github.com/radek1st)
-
-##### 3.2.3
-* Dumping more debug information to the console if `--debug` option is on, also for successfully matched requests
-* Added support for `PUT` and `DELETE` methods in `StubbyClient` class
-
-##### 3.1.3
-* If POST'ed data type is `application/json`, the comparison of stubbed to posted data will be done using JSON entities with non-strict checking (content ordering wont matter, as long as it is the same)
-* If POST'ed data type is `application/xml`, the comparison of stubbed to posted data will be done using XML entities with non-strict checking (element & attribute ordering wont matter, as long as content is the same)
-
-##### 3.0.3
-* Added support for custom authorization type header with the help of the new `header` property `authorization-custom`
-* Fixed issue #43 (Live refresh in response sequence only for first response)
-
-##### 3.0.2
-* Added support for Bearer Token authorization with the help of the new `header` property `authorization-bearer`
-* Renamed existing `header` property `authorization` to `authorization-basic`
-* Some changes around the programmatic APIs in `StubbyClient` class due to the above changes
-* Respective changes in the current README due to the above changes
-
-##### 3.0.1
-* Upgraded Jetty to v9.2.10.v20150310
-* Added `--debug` option that dumps incoming raw HTTP request to the console
-* Added `--disable_admin_portal` option that does not configure Admin portal for stubby
-* Added `--disable_ssl` option that does not enable SSL for stubby
-* Added a new API to start stubby programmatically without specifying a YAML file `StubbyClient.startJettyYamless(...)`
-* Added a new `FaviconHandler` to handle requests for `favicon.ico` under the context root
-
-##### 3.0.0
-* Built using Java v1.7.0_76
-* Updated Jetty to v9.2.9.v20150224 (requires at least JRE v1.7.0_76: [Issue with Java v1.7.0_04](http://dev.eclipse.org/mhonarc/lists/jetty-users/msg05635.html))
-
-##### 2.0.22
-* Built using Java v1.7.0_04
-* Cleaned up project Gradle configuration 
-* Updated Gradle configuration to be compatible with Gradle v2.2.1 & Gradle Nexus plugin v2.3
-* Updated all (except Jetty) dependencies to their latest versions (as of May 10th, 2015)
-
-##### 2.0.21
-* Added console outputs for record & play functionality
-
-##### 2.0.20
-* Replacing all hardcoded `\n` with dynamically generated system line break characters
-
-##### 2.0.19
-* Record&Play is now more intelligent: when stubbed `request` is matched, its stubbed properties (`method`, `url`, `headers`, `post` and `query`) are used to construct HTTP request to the recordable destination URL provided in stubbed `response` body [ENHANCEMENT]
-* Added a workaround a limitation in SnakeYAML v1.13 used by stubby (it has limited JSON support, not all the JSON documents can be parsed) where it cannot parse escaped forward slashes in JSON [BUG]
-* Refreshing Admin status page was changing sequenced response counter ID [BUG]
-* Replaced hardcoded Unix new line character '\n' in YamlBuilderTest that caused the tests to fail on Windows [BUG]
-* Admin status page now shows what is the next sequenced response in the sequence queue [ENHANCEMENT]
-* Supporting HTTP requests with empty query params: `/uri?some_param=` or `/uri?some_param` [ENHANCEMENT]
-
-##### 2.0.18
-* When `--data` file was just a relative filename without parent directory, NPE was thrown when Admin portal status page was loaded [BUG]
-* Configured jetty GZIP handler for static resources and Stubs & Admin portals [ENHANCEMENT]
-* Added resource hit stats section to Admin portal status page [ENHANCEMENT]
-
-##### 2.0.17
-* Added a verification check in StubbyManager to make sure that Jetty has been started or shut down [ENHANCEMENT]
-* Upgraded SnakeYAML dependency library to v1.13 [ENHANCEMENT]
-* Admin status page: displaying YAML snippet for a given `request` or `response` separately instead of pairing them up [ENHANCEMENT]
-* Admin status page: displaying metadata of loaded external files (if any) [ENHANCEMENT]
-* Admin status page: displaying Ajax response in a JS popup, instead of injecting the Ajax response into HTML table [ENHANCEMENT]
-* A bunch of cosmetic changes on Admin status page [COSMETICS]
-
-##### 2.0.16
-* Displaying stubby JAR: version, its classpath location, built date, up-time, its input args and Java input args on status page [ENHANCEMENT]
-* Displaying stubby heap/non-heap memory usage on status page [ENHANCEMENT]
-* Added an option on admin status page to display YAML snippet for a given request & response pair [ENHANCEMENT]
-* Making sure that 'x-stubby-resource-id' header is always the first item in the stubbed headers on status page [ENHANCEMENT]
-* Changed colors of status page [COSMETICS]
-
-##### 2.0.15
-* When creating template token names for `query` or `headers` regex matches, the name format to be followed should be `headers.key_name.ID` or `query.key_name.ID` [ENHANCEMENT]
-
-##### 2.0.14
-* Whitespace was not allowed between the `<% ` & ` %>` and what's inside when specifying template tokens for dynamic token replacement in stubbed response [BUG]
-* Regex matches were stored against incorrect token names for `query` and `headers` regexes [BUG]
-* Renamed command line arg `--ssl` to `--tls` to reduce the confusion when having another command line arg that starts with letter `s`, like `--stubs` [ENHANCEMENT]
-* Added command line arg `--version` that prints current stubby4j version to the console [ENHANCEMENT]
-
-##### 2.0.13
-* Dynamic token replacement in stubbed response, by leveraging regex capturing groups as token values during HTTP request verification [FEATURE]
-
-##### 2.0.12
-* Removed flag `--watch_sleep_time`. The `--watch` flag can now accept an optional arg value which is the watch scan time in milliseconds. If milliseconds is not provided, the watch scans every 100ms [ENHANCEMENT]
-* Added additional API to start Jetty via StubbyClient by specifying an address to bind [ENHANCEMENT]
-
-##### 2.0.11
-* `--watch` flag sleep time is now configurable via `--watch_sleep_time` and defaults to `100ms` if `--watch_sleep_time` is not provided [ENHANCEMENT]
-* Added a `GET` endpoint on Admin portal `localhost:8889/refresh` for refreshing stubbed data [ENHANCEMENT]
-
-##### 2.0.10
-* Record & Replay. The HTTP traffic is recorded on the first call to stubbed `uri` and subsequent calls will play back the recorded HTTP response, without actually connecting to the external server [FEATURE]
-
-##### 2.0.9
-* Ensuring that Admin portal status page loads fast by not rendering stubbed response content which slows down page load. User can invoke Ajax request to fetch the desired response content as needed [ENHANCEMENT]
-* Pre-setting header `x-stubby-resource-id` during YAML parse time, instead of on demand. This way resource IDs are viewable on Admin status page [ENHANCEMENT]
-* Making sure that header `x-stubby-resource-id` is recalculated accordingly after stubbed data in memory has changed (due to reset, or deletion etc.) [BUG]
-* Added date stamp to live reload success message [COSMETICS]
-
-##### 2.0.8
-* Making sure that every stubbed response returned to the client contains its resource ID in the header `x-stubby-resource-id`. The latter is useful if the returned resource needs to be updated at run time by ID via Admin portal [FEATURE]
-
-##### 2.0.7
-* Force regex matching only everywhere (url, query, post, headers, etc.) to avoid confusion and unexpected behaviour, with default fallback to simple full-string match (Michael England) [ENHANCEMENT]
-
-##### 2.0.6
-* Live YAML scan now also check for modifications to external files referenced from main YAML [ENHANCEMENT]
-* YAML parsing logic revisited [COSMETICS]
-* Code cleanup [COSMETICS]
-
-##### 2.0.5
-* Added ability to specify sequence of responses on the same URI using `file` (Prakash Kandavel) [ENHANCEMENT]
-* Minor code clean up [COSMETICS]
-* Documentation update [COSMETICS]
-
-##### 2.0.4
-* Making sure that operations starting up stubby and managing stubbed data are atomic  [ENHANCEMENT]
-
-##### 2.0.3
-* Typo in test was giving wrong indication that when `file` not set, stubbed response fallsback to `body` [BUG]
-* Eliminated implicit test to test dependencies in AdminPortalTest that was causing issues when running the tests under JDK 1.7 [BUG]
-* Added convenience method in StubbyClient `updateStubbedData` [ENHANCEMENT]
-
-##### 2.0.2
-* Stubbed request HTTP header names were not lower-cased at the time of match [BUG]
-* Doing GET on Admin portal `/` will display all loaded stub data in a YAML format in the browser [FEATURE]
-* Doing GET on Admin portal `/<id>` will display loaded stub data matched by provided index in a YAML format in the browser [FEATURE]
-* Doing DELETE on Admin portal `/<id>` will delete stubbed request from the list of loaded stub requests using the index provided [FEATURE]
-* Doing PUT on Admin portal `/<id>` will update stubbed request in the list of loaded stub requests using the index provided [FEATURE]
-* When YAML is parsed, if `file` could not be loaded, the IOException is not thrown anymore. Instead a warning recorded in the terminal [ENHANCEMENT]
-* When could not match submitted HTTP request to stubbed requests, the not found message is much more descriptive [ENHANCEMENT]
-* URI for registering new stub data programmatically via POST on Admin portal was changed from `/stubdata/new` to `/` [COSMETICS]
-* URI for getting loaded stub data status was changed from `/ping` to `/status` on Admin portal [COSMETICS]
-* Updated to SnakeYAML v1.12 [COSMETICS]
-* Updated default response message when response content could not be loaded from `file` [ENHANCEMENT]
-* Documentation refinement [COSMETICS]
-
-##### 2.0.1
-* Every ```url``` is treated as a regular expression now [ENHANCEMENT]
-* ANSI logging in the terminal was working only for HTTP requests with status 200 [BUG]
-* Documentation refinement [COSMETICS]
-
-##### 2.0.0
-* Mainly backend code improvements: A lot of refactoring for better code readability, expanding test coverage [COSMETICS]
-
-##### 1.0.63
-* Added ability to specify sequence of stub responses for the same URI, that are sent to the client in the loop [FEATURE]
-* Configuration scan was not enabled, even if the ```--watch``` command line argument was passed [BUG]
-
-##### 1.0.62
-* Added ability to specify regex in stabbed URL for dynamic matching [FEATURE]
-* A lot of minor fixes, refactorings and code cleaned up [COSMETICS]
-* Documentation revisited and rewritten into a much clearer format [ENHANCEMENT]
-
-##### 1.0.61
-* Just some changes around unit, integration and functional tests. Code cleanup [COSMETICS]
-
-##### 1.0.60
-* stubby's admin page was generating broken hyper links if URL had single quotes [BUG]
-* stubby is able to match URL when query string param was an array with elements within single quotes, ie: ```attributes=['id','uuid']``` [ENHANCEMENT]
-
-##### 1.0.59
-* stubby's admin page was not able to display the contents of stubbed response/request ```body```, ```post``` or ```file``` [BUG]
-* stubby was not able to match URL when query string param was an array with quoted elements, ie: ```attributes=["id","uuid","created","lastUpdated","displayName","email"]``` [BUG]
-
-##### 1.0.58
-* Making sure that stubby can serve binary files as well as ascii files, when response is loaded using the ```file``` property [ENHANCEMENT]
-
-##### 1.0.57
-* Migrated the project from Maven to Gradle (thanks to [Logan McGrath](https://github.com/lmcgrath) for his feedback and assistance). The project has now a multi-module setup [ENHANCEMENT]
-
-##### 1.0.56
-* If `request.post` was left out of the configuration, stubby would ONLY match requests without a post body to it [BUG]
-* Fixing `See Also` section of readme [COSMETICS]
-
-##### 1.0.55
-* Updated YAML example documentation [COSMETICS]
-* Bug fix where command line options `mute`, `debug` and `watch` were overlooked [BUG]
-
-##### 1.0.54
-* Previous commit (`v1.0.53`) unintentionally broke use of embedded stubby [BUG]
-
-### Roadmap
+## Roadmap
 * Add support for OAuth in Record & Replay feature
 * Scenarios where multiple endpoints correlate with each other based on the scenario. Useful in e2e testing where system brought to a certain state (maybe?)
 
-### Authors
+## Authors
 A number of people have contributed directly to stubby4j by writing
 documentation or developing software.
 
@@ -1484,7 +1276,7 @@ documentation or developing software.
 2. Eric Mrak <enmrak@gmail.com>
 
 
-### Kudos
+## Kudos
 A number of people have contributed to stubby4j by reporting problems, suggesting improvements or submitting changes. Special thanks fly out to the following **Ninjas** for their help, support and feedback
 
 * Isa Goksu
@@ -1497,15 +1289,15 @@ A number of people have contributed to stubby4j by reporting problems, suggestin
 * Logan McGrath
 
 
-### See also
+## See also
 * **[stubby4net](https://github.com/mrak/stubby4net):** A .NET implementation of stubby
 * **[stubby4node](https://github.com/mrak/stubby4node):** A node.js implementation of stubby
 
 
-### Copyright
+## Copyright
 Yes. See COPYRIGHT for details
 
-### License
+## License
 MIT. See LICENSE for details
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,9 +3,9 @@ codecov:
   bot: null
 
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
+  precision: 0
+  round: up
+  range: "60...100"
 
   notify:
     slack:

--- a/conf/gradle/artifacts.gradle
+++ b/conf/gradle/artifacts.gradle
@@ -1,3 +1,11 @@
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
+        .ofPattern("yyyy-MM-dd HH:mm:ssZ")
+        .withZone(ZoneOffset.systemDefault())
+
 project.ext.dependenciesWithJetty = configurations.compile.resolve().findAll { file ->
     return /*!file.name.contains("servlet-api") && */ !file.name.contains("-sources")
 }
@@ -15,7 +23,7 @@ project.ext.projectManifest = manifest {
             'Implementation-Version': "${version}",
             'Implementation-Vendor': 'Alexander Zagniotov',
             'Built-By': 'Alexander Zagniotov',
-            'Built-Date': new Date().toString(),
+            'Built-Date': DATE_TIME_FORMATTER.format(Instant.now()),
             'Built-With': "gradle-${project.getGradle().getGradleVersion()}, groovy-${GroovySystem.getVersion()}",
             'Created-By': System.getProperty('java.version') + ' (' + System.getProperty('java.vendor') + ')'
 }
@@ -29,7 +37,7 @@ project.ext.projectManifestNoJetty = manifest {
             'Implementation-Version': "${version}",
             'Implementation-Vendor': 'Alexander Zagniotov',
             'Built-By': 'Alexander Zagniotov',
-            'Built-Date': new Date().toString(),
+            'Built-Date': DATE_TIME_FORMATTER.format(Instant.now()),
             'Built-With': "gradle-${project.getGradle().getGradleVersion()}, groovy-${GroovySystem.getVersion()}",
             'Created-By': System.getProperty('java.version') + ' (' + System.getProperty('java.vendor') + ')'
 }

--- a/conf/gradle/cobertura.gradle
+++ b/conf/gradle/cobertura.gradle
@@ -38,7 +38,7 @@ task coberturaInstrument(dependsOn: ['classes', 'coberturaPrepare']) {
             )
             fileset(
                     dir: project(':main').sourceSets.main.output.classesDir,
-                    excludes: "${root}/yaml/YAMLBuilder*.class, **/*\$1.class, **/*\$2.class",
+                    excludes: "${root}/caching/**/*.class, ${root}/client/StubbyClient*.class, ${root}/yaml/YamlBuilder*.class, ${root}/yaml/YamlParseResultSet.class, **/*\$1.class, **/*\$2.class",
                     includes: "${root}/client/**/*.class, " +
                             "${root}/cli/CommandLineInterpreter.class, " +
                             "${root}/utils/*.class, " +

--- a/conf/gradle/dependency.gradle
+++ b/conf/gradle/dependency.gradle
@@ -1,11 +1,12 @@
 // vim: ft=groovy
 dependencies {
-    compile "org.eclipse.jetty:jetty-server:9.4.8.v20171121"
-    compile "org.eclipse.jetty:jetty-servlets:9.4.8.v20171121"
+    compile "org.eclipse.jetty:jetty-server:9.4.9.v20180320"
+    compile "org.eclipse.jetty:jetty-servlets:9.4.9.v20180320"
+    compile "org.ehcache:ehcache:3.5.2"
     compile "commons-cli:commons-cli:1.2"
-    compile "org.yaml:snakeyaml:1.17"
+    compile "org.yaml:snakeyaml:1.20"
     compile "org.skyscreamer:jsonassert:1.3.0"
-    compile "xmlunit:xmlunit:1.6"
+    compile 'org.xmlunit:xmlunit-core:2.5.1'
     compile "io.github.azagniotov:collection-type-safe-converter:1.0.1"
     compile "org.slf4j:slf4j-api:1.7.25"
 

--- a/functional/java/io/github/azagniotov/stubby4j/StubsAdminPortalsTest.java
+++ b/functional/java/io/github/azagniotov/stubby4j/StubsAdminPortalsTest.java
@@ -10,7 +10,7 @@ import io.github.azagniotov.stubby4j.client.StubbyResponse;
 import io.github.azagniotov.stubby4j.common.Common;
 import io.github.azagniotov.stubby4j.stubs.StubResponse;
 import io.github.azagniotov.stubby4j.utils.StringUtils;
-import io.github.azagniotov.stubby4j.yaml.YAMLBuilder;
+import io.github.azagniotov.stubby4j.yaml.YamlBuilder;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -62,7 +62,7 @@ public class StubsAdminPortalsTest {
     @Test
     public void should_UpdateStubsDataAndGetNewResource_WhenSuccessfulValidPostMade_ToAdminPortalRoot() throws Exception {
 
-        final String yamlToUpdate = new YAMLBuilder()
+        final String yamlToUpdate = new YamlBuilder()
                 .newStubbedRequest()
                 .withUrl("^/new/resource/.*$")
                 .withMethodGet()

--- a/functional/resources/json/update.request.by.uuid.json
+++ b/functional/resources/json/update.request.by.uuid.json
@@ -1,0 +1,21 @@
+[
+   {
+      "uuid": "9136d8b7-f7a7-478d-97a5-53292484aaf6",
+      "request": {
+         "url": "/with/UPDATED/uuid/property",
+         "query": {
+            "someKey": "someValue"
+         },
+         "method": [
+            "GET"
+         ]
+      },
+      "response": {
+         "body": "OK",
+         "headers": {
+            "content-type": "application/xml"
+         },
+         "status": 201
+      }
+   }
+]

--- a/functional/resources/yaml/stubs.yaml
+++ b/functional/resources/yaml/stubs.yaml
@@ -711,6 +711,7 @@
       body: >
          {"id" : "12", "description" : "deleted authorized using bearer"}
 
+
 -  request:
       method: [GET]
       url: ^/v\d/identity/authorize
@@ -722,6 +723,7 @@
          location: https://<% query.redirect_uri.1 %>/auth
       status: 302
 
+
 -  request:
       method: [GET]
       url: /returns-not-found-response-with-body
@@ -729,3 +731,17 @@
    response:
       status: 404
       body: This response with body was actually not found
+
+
+-  uuid: 9136d8b7-f7a7-478d-97a5-53292484aaf6
+   request:
+      method: GET
+      url: /with/configured/uuid/property
+
+   response:
+      headers:
+         content-type: application/json
+      status: 200
+      body: >
+         {"status" : "OK"}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ org.gradle.parallel=true
 configureondemand=true
 stubbyProjectName=stubby4j
 stubbyProjectGroup=io.github.azagniotov
-version=5.2.0
+version=6.0.1-SNAPSHOT
 

--- a/integration/java/io/github/azagniotov/stubby4j/yaml/YamlParserLoadTest.java
+++ b/integration/java/io/github/azagniotov/stubby4j/yaml/YamlParserLoadTest.java
@@ -5,14 +5,12 @@ import io.github.azagniotov.stubby4j.stubs.StubRequest;
 import io.github.azagniotov.stubby4j.stubs.StubResponse;
 import org.junit.Test;
 
-import java.util.List;
-
 import static com.google.common.truth.Truth.assertThat;
 import static io.github.azagniotov.stubby4j.utils.FileUtils.BR;
 
-public class YAMLParserLoadTest {
+public class YamlParserLoadTest {
 
-    private static final YAMLBuilder YAML_BUILDER = new YAMLBuilder();
+    private static final YamlBuilder YAML_BUILDER = new YamlBuilder();
 
 
     @Test
@@ -52,10 +50,10 @@ public class YAMLParserLoadTest {
         final String rawYaml = BUILDER.toString();
         BUILDER.setLength(0);
 
-        final List<StubHttpLifecycle> loadedHttpCycles = loadYamlToDataStore(rawYaml);
-        assertThat(loadedHttpCycles.size()).isEqualTo(NUMBER_OF_HTTPCYCLES);
+        final YamlParseResultSet yamlParseResultSet = loadYamlToDataStore(rawYaml);
+        assertThat(yamlParseResultSet.getStubs().size()).isEqualTo(NUMBER_OF_HTTPCYCLES);
 
-        final StubHttpLifecycle actualHttpLifecycle = loadedHttpCycles.get(498);
+        final StubHttpLifecycle actualHttpLifecycle = yamlParseResultSet.getStubs().get(498);
         final StubRequest actualRequest = actualHttpLifecycle.getRequest();
         final StubResponse actualResponse = actualHttpLifecycle.getResponse(true);
 
@@ -66,8 +64,8 @@ public class YAMLParserLoadTest {
         assertThat(actualResponse.getHeaders()).containsEntry(expectedHeaderKey, expectedHeaderValue);
     }
 
-    private List<StubHttpLifecycle> loadYamlToDataStore(final String yaml) throws Exception {
-        return new YAMLParser().parse(".", yaml);
+    private YamlParseResultSet loadYamlToDataStore(final String yaml) throws Exception {
+        return new YamlParser().parse(".", yaml);
     }
 
 }

--- a/integration/resources/yaml/duplicated.uuid.stub.yaml
+++ b/integration/resources/yaml/duplicated.uuid.stub.yaml
@@ -1,0 +1,20 @@
+-  description: Stub one
+   uuid: 9136d8b7-f7a7-478d-97a5-53292484aaf6
+   request:
+      url: ^/one$
+      method: GET
+
+   response:
+      status: 200
+      body: 'One!'
+
+
+-  description: Stub two
+   uuid: 9136d8b7-f7a7-478d-97a5-53292484aaf6
+   request:
+      url: ^/two
+      method: GET
+
+   response:
+      status: 200
+      body: 'Two!'

--- a/integration/resources/yaml/feature.stub.yaml
+++ b/integration/resources/yaml/feature.stub.yaml
@@ -1,0 +1,20 @@
+-  description: Stub one
+   uuid: 9136d8b7-f7a7-478d-97a5-53292484aaf6
+   request:
+      url: ^/one$
+      method: GET
+
+   response:
+      status: 200
+      latency: 100
+      body: 'One!'
+
+-  description: Stub two
+   uuid: 888975hn-f7a7-8888-97a5-53292484aaf6
+   request:
+      url: ^/two
+      method: GET
+
+   response:
+      status: 200
+      body: 'Two!'

--- a/main/java/io/github/azagniotov/stubby4j/caching/Cache.java
+++ b/main/java/io/github/azagniotov/stubby4j/caching/Cache.java
@@ -1,0 +1,49 @@
+package io.github.azagniotov.stubby4j.caching;
+
+
+import org.ehcache.UserManagedCache;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public interface Cache<K, V> {
+
+    static Cache stubHttpLifecycleCache(final long cacheEntryLifetimeSeconds) {
+        return new StubHttpLifecycleCache(cacheEntryLifetimeSeconds);
+    }
+
+    static Cache regexPatternCache(final long cacheEntryLifetimeSeconds) {
+        return new RegexPatternCache(cacheEntryLifetimeSeconds);
+    }
+
+    default Optional<V> get(final K key) {
+        return Optional.<V>ofNullable(cache().get(key));
+    }
+
+    default void putIfAbsent(final K key, final V value) {
+        if (!cache().containsKey(key)) {
+            cache().put(key, value);
+            size().incrementAndGet();
+        }
+    }
+
+    default void clearByKey(final K key) {
+        if (cache().containsKey(key)) {
+            cache().remove(key);
+            size().decrementAndGet();
+        }
+    }
+
+    default void clear() {
+        cache().clear();
+        size().set(0);
+    }
+
+    default void close() {
+        cache().close();
+    }
+
+    UserManagedCache<K, V> cache();
+
+    AtomicInteger size();
+}

--- a/main/java/io/github/azagniotov/stubby4j/caching/RegexPatternCache.java
+++ b/main/java/io/github/azagniotov/stubby4j/caching/RegexPatternCache.java
@@ -1,0 +1,40 @@
+package io.github.azagniotov.stubby4j.caching;
+
+
+import org.ehcache.UserManagedCache;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.builders.UserManagedCacheBuilder;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+class RegexPatternCache implements Cache<Integer, Pattern> {
+
+    private final AtomicInteger size;
+    private final UserManagedCache<Integer, Pattern> cache;
+
+    RegexPatternCache(final long cacheEntryLifetimeSeconds) {
+        final Duration timeToLiveExpiration = Duration.ofSeconds(cacheEntryLifetimeSeconds);
+
+        this.cache = UserManagedCacheBuilder
+                .newUserManagedCacheBuilder(Integer.class, Pattern.class)
+                .withResourcePools(ResourcePoolsBuilder.heap(500L))
+                .identifier(this.getClass().getSimpleName())
+                .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(timeToLiveExpiration))
+                .build(true);
+
+        this.size = new AtomicInteger(0);
+    }
+
+    @Override
+    public UserManagedCache<Integer, Pattern> cache() {
+        return cache;
+    }
+
+    @Override
+    public AtomicInteger size() {
+        return size;
+    }
+}

--- a/main/java/io/github/azagniotov/stubby4j/caching/StubHttpLifecycleCache.java
+++ b/main/java/io/github/azagniotov/stubby4j/caching/StubHttpLifecycleCache.java
@@ -1,0 +1,40 @@
+package io.github.azagniotov.stubby4j.caching;
+
+
+import io.github.azagniotov.stubby4j.stubs.StubHttpLifecycle;
+import org.ehcache.UserManagedCache;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.config.builders.UserManagedCacheBuilder;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class StubHttpLifecycleCache implements Cache<String, StubHttpLifecycle> {
+
+    private final AtomicInteger size;
+    private final UserManagedCache<String, StubHttpLifecycle> cache;
+
+    StubHttpLifecycleCache(final long cacheEntryLifetimeSeconds) {
+        final Duration timeToLiveExpiration = Duration.ofSeconds(cacheEntryLifetimeSeconds);
+
+        this.cache = UserManagedCacheBuilder
+                .newUserManagedCacheBuilder(String.class, StubHttpLifecycle.class)
+                .withResourcePools(ResourcePoolsBuilder.heap(500L))
+                .identifier(this.getClass().getSimpleName())
+                .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(timeToLiveExpiration))
+                .build(true);
+
+        this.size = new AtomicInteger(0);
+    }
+
+    @Override
+    public UserManagedCache<String, StubHttpLifecycle> cache() {
+        return cache;
+    }
+
+    @Override
+    public AtomicInteger size() {
+        return size;
+    }
+}

--- a/main/java/io/github/azagniotov/stubby4j/filesystem/ExternalFilesScanner.java
+++ b/main/java/io/github/azagniotov/stubby4j/filesystem/ExternalFilesScanner.java
@@ -2,12 +2,12 @@ package io.github.azagniotov.stubby4j.filesystem;
 
 import io.github.azagniotov.stubby4j.cli.ANSITerminal;
 import io.github.azagniotov.stubby4j.stubs.StubRepository;
-import io.github.azagniotov.stubby4j.yaml.YAMLParser;
+import io.github.azagniotov.stubby4j.utils.DateTimeUtils;
+import io.github.azagniotov.stubby4j.yaml.YamlParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Date;
 import java.util.Map;
 
 import static io.github.azagniotov.stubby4j.utils.FileUtils.BR;
@@ -21,9 +21,9 @@ public final class ExternalFilesScanner implements Runnable {
     public ExternalFilesScanner(final StubRepository stubRepository, final long sleepTime) {
         this.sleepTime = sleepTime;
         this.stubRepository = stubRepository;
-        ANSITerminal.status(String.format("External file scan enabled, watching external files referenced from %s", stubRepository.getYAMLConfigCanonicalPath()));
+        ANSITerminal.status(String.format("External file scan enabled, watching external files referenced from %s", stubRepository.getYamlConfigCanonicalPath()));
         LOGGER.debug("External file scan enabled, watching external files referenced from {}.",
-                stubRepository.getYAMLConfigCanonicalPath());
+                stubRepository.getYamlConfigCanonicalPath());
     }
 
     @Override
@@ -59,12 +59,12 @@ public final class ExternalFilesScanner implements Runnable {
                 LOGGER.info("External file scan detected change in {}.", offendingFilename);
 
                 try {
-                    stubRepository.refreshStubsFromYAMLConfig(new YAMLParser());
+                    stubRepository.refreshStubsFromYamlConfig(new YamlParser());
 
-                    ANSITerminal.ok(String.format("%sSuccessfully performed live refresh of main YAML with external files from: %s on [" + new Date().toString().trim() + "]%s",
-                            BR, stubRepository.getYAMLConfig(), BR));
+                    ANSITerminal.ok(String.format("%sSuccessfully performed live refresh of main YAML with external files from: %s on [" + DateTimeUtils.systemDefault() + "]%s",
+                            BR, stubRepository.getYamlConfig(), BR));
                     LOGGER.info("Successfully performed live refresh of main YAML with external files from: {}.",
-                            stubRepository.getYAMLConfig());
+                            stubRepository.getYamlConfig());
                 } catch (final Exception ex) {
                     ANSITerminal.error("Could not refresh YAML configuration, previously loaded stubs remain untouched." + ex.toString());
                     LOGGER.error("Could not refresh YAML configuration, previously loaded stubs remain untouched.", ex);

--- a/main/java/io/github/azagniotov/stubby4j/filesystem/MainYamlScanner.java
+++ b/main/java/io/github/azagniotov/stubby4j/filesystem/MainYamlScanner.java
@@ -2,12 +2,12 @@ package io.github.azagniotov.stubby4j.filesystem;
 
 import io.github.azagniotov.stubby4j.cli.ANSITerminal;
 import io.github.azagniotov.stubby4j.stubs.StubRepository;
-import io.github.azagniotov.stubby4j.yaml.YAMLParser;
+import io.github.azagniotov.stubby4j.utils.DateTimeUtils;
+import io.github.azagniotov.stubby4j.yaml.YamlParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Date;
 
 import static io.github.azagniotov.stubby4j.utils.FileUtils.BR;
 
@@ -20,15 +20,15 @@ public final class MainYamlScanner implements Runnable {
     public MainYamlScanner(final StubRepository stubRepository, final long sleepTime) {
         this.sleepTime = sleepTime;
         this.stubRepository = stubRepository;
-        ANSITerminal.status(String.format("Main YAML scan enabled, watching %s", stubRepository.getYAMLConfigCanonicalPath()));
-        LOGGER.debug("Main YAML scan enabled, watching {}.", stubRepository.getYAMLConfigCanonicalPath());
+        ANSITerminal.status(String.format("Main YAML scan enabled, watching %s", stubRepository.getYamlConfigCanonicalPath()));
+        LOGGER.debug("Main YAML scan enabled, watching {}.", stubRepository.getYamlConfigCanonicalPath());
     }
 
     @Override
     public void run() {
 
         try {
-            final File dataYaml = stubRepository.getYAMLConfig();
+            final File dataYaml = stubRepository.getYamlConfig();
             long mainYamlLastModified = dataYaml.lastModified();
 
             while (!Thread.currentThread().isInterrupted()) {
@@ -40,14 +40,14 @@ public final class MainYamlScanner implements Runnable {
                     continue;
                 }
 
-                ANSITerminal.info(String.format("%sMain YAML scan detected change in %s%s", BR, stubRepository.getYAMLConfigCanonicalPath(), BR));
-                LOGGER.info("Main YAML scan detected change in  {}.", stubRepository.getYAMLConfigCanonicalPath());
+                ANSITerminal.info(String.format("%sMain YAML scan detected change in %s%s", BR, stubRepository.getYamlConfigCanonicalPath(), BR));
+                LOGGER.info("Main YAML scan detected change in  {}.", stubRepository.getYamlConfigCanonicalPath());
 
                 try {
                     mainYamlLastModified = currentFileModified;
-                    stubRepository.refreshStubsFromYAMLConfig(new YAMLParser());
+                    stubRepository.refreshStubsFromYamlConfig(new YamlParser());
 
-                    ANSITerminal.ok(String.format("%sSuccessfully performed live refresh of main YAML file from: %s on [" + new Date().toString().trim() + "]%s",
+                    ANSITerminal.ok(String.format("%sSuccessfully performed live refresh of main YAML file from: %s on [" + DateTimeUtils.systemDefault() + "]%s",
                             BR, dataYaml.getAbsolutePath(), BR));
                     LOGGER.info("Successfully performed live refresh of main YAML from: {}.",
                             dataYaml.getAbsolutePath());

--- a/main/java/io/github/azagniotov/stubby4j/handlers/AjaxResourceContentHandler.java
+++ b/main/java/io/github/azagniotov/stubby4j/handlers/AjaxResourceContentHandler.java
@@ -97,7 +97,7 @@ public class AjaxResourceContentHandler extends AbstractHandler {
         try {
             final String ajaxResponse = foundStub.getAjaxResponseContent(stubType, targetFieldName);
             final String popupHtmlTemplate = getHtmlResourceByName("_popup_generic");
-            final String htmlPopup = String.format(popupHtmlTemplate, foundStub.getResourceId(), targetFieldName, ajaxResponse);
+            final String htmlPopup = String.format(popupHtmlTemplate, foundStub.getResourceId(), foundStub.getUUID(), ajaxResponse);
             response.getWriter().println(htmlPopup);
         } catch (final Exception ex) {
             HandlerUtils.configureErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR_500, ex.toString());
@@ -109,7 +109,7 @@ public class AjaxResourceContentHandler extends AbstractHandler {
         try {
             final String ajaxResponse = foundStub.getAjaxResponseContent(targetFieldName, sequencedResponseId);
             final String popupHtmlTemplate = getHtmlResourceByName("_popup_generic");
-            final String htmlPopup = String.format(popupHtmlTemplate, foundStub.getResourceId(), targetFieldName, ajaxResponse);
+            final String htmlPopup = String.format(popupHtmlTemplate, foundStub.getResourceId(), foundStub.getUUID(), ajaxResponse);
             response.getWriter().println(htmlPopup);
         } catch (final Exception ex) {
             HandlerUtils.configureErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR_500, ex.toString());

--- a/main/java/io/github/azagniotov/stubby4j/handlers/StatusPageHandler.java
+++ b/main/java/io/github/azagniotov/stubby4j/handlers/StatusPageHandler.java
@@ -25,6 +25,7 @@ import io.github.azagniotov.stubby4j.stubs.StubHttpLifecycle;
 import io.github.azagniotov.stubby4j.stubs.StubRepository;
 import io.github.azagniotov.stubby4j.stubs.StubResponse;
 import io.github.azagniotov.stubby4j.utils.ConsoleUtils;
+import io.github.azagniotov.stubby4j.utils.DateTimeUtils;
 import io.github.azagniotov.stubby4j.utils.HandlerUtils;
 import io.github.azagniotov.stubby4j.utils.JarUtils;
 import io.github.azagniotov.stubby4j.utils.ObjectUtils;
@@ -45,7 +46,6 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.RuntimeMXBean;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -188,7 +188,7 @@ public final class StatusPageHandler extends AbstractHandler {
         builder.append(interpolateHtmlTableRowTemplate("UPTIME", HandlerUtils.calculateStubbyUpTime(RUNTIME_MX_BEAN.getUptime())));
         builder.append(interpolateHtmlTableRowTemplate("INPUT ARGS", CommandLineInterpreter.PROVIDED_OPTIONS));
         builder.append(interpolateHtmlTableRowTemplate("STUBBED ENDPOINTS", stubRepository.getStubs().size()));
-        builder.append(interpolateHtmlTableRowTemplate("LOADED YAML", buildLoadedFileMetadata(stubRepository.getYAMLConfig())));
+        builder.append(interpolateHtmlTableRowTemplate("LOADED YAML", buildLoadedFileMetadata(stubRepository.getYamlConfig())));
 
         if (!stubRepository.getExternalFiles().isEmpty()) {
             final StringBuilder externalFilesMetadata = new StringBuilder();
@@ -219,7 +219,7 @@ public final class StatusPageHandler extends AbstractHandler {
         builder.append(String.format(TEMPLATE_LOADED_FILE_METADATA_PAIR, "parentDir", determineParentDir(file))).append("<br />");
         builder.append(String.format(TEMPLATE_LOADED_FILE_METADATA_PAIR, "name", file.getName())).append("<br />");
         builder.append(String.format(TEMPLATE_LOADED_FILE_METADATA_PAIR, "size", String.format("%1$,.2f", ((double) file.length() / 1024)) + "kb")).append("<br />");
-        builder.append(String.format(TEMPLATE_LOADED_FILE_METADATA_PAIR, "lastModified", new Date(file.lastModified()))).append("<br />");
+        builder.append(String.format(TEMPLATE_LOADED_FILE_METADATA_PAIR, "lastModified", DateTimeUtils.systemDefault(file.lastModified()))).append("<br />");
 
         return "<div style='margin-top: 5px; padding: 3px 7px 3px 7px; background-color: #fefefe'>" + builder.toString() + "</div>";
     }

--- a/main/java/io/github/azagniotov/stubby4j/handlers/StubDataRefreshActionHandler.java
+++ b/main/java/io/github/azagniotov/stubby4j/handlers/StubDataRefreshActionHandler.java
@@ -22,8 +22,9 @@ package io.github.azagniotov.stubby4j.handlers;
 import io.github.azagniotov.stubby4j.cli.ANSITerminal;
 import io.github.azagniotov.stubby4j.stubs.StubRepository;
 import io.github.azagniotov.stubby4j.utils.ConsoleUtils;
+import io.github.azagniotov.stubby4j.utils.DateTimeUtils;
 import io.github.azagniotov.stubby4j.utils.HandlerUtils;
-import io.github.azagniotov.stubby4j.yaml.YAMLParser;
+import io.github.azagniotov.stubby4j.yaml.YamlParser;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
@@ -35,7 +36,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Date;
 
 @SuppressWarnings("serial")
 public final class StubDataRefreshActionHandler extends AbstractHandler {
@@ -60,12 +60,12 @@ public final class StubDataRefreshActionHandler extends AbstractHandler {
         response.setHeader(HttpHeader.SERVER.asString(), HandlerUtils.constructHeaderServerName());
 
         try {
-            stubRepository.refreshStubsFromYAMLConfig(new YAMLParser());
-            final String successMessage = String.format("Successfully performed live refresh of main YAML from: %s on [" + new Date().toString().trim() + "]",
-                    stubRepository.getYAMLConfig());
+            stubRepository.refreshStubsFromYamlConfig(new YamlParser());
+            final String successMessage = String.format("Successfully performed live refresh of main YAML from: %s on [" + DateTimeUtils.systemDefault() + "]",
+                    stubRepository.getYamlConfig());
             response.getWriter().println(successMessage);
             ANSITerminal.ok(successMessage);
-            LOGGER.info("Successfully performed live refresh of main YAML from {}.", stubRepository.getYAMLConfig());
+            LOGGER.info("Successfully performed live refresh of main YAML from {}.", stubRepository.getYamlConfig());
         } catch (final Exception ex) {
             HandlerUtils.configureErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR_500, ex.toString());
         }

--- a/main/java/io/github/azagniotov/stubby4j/handlers/strategy/admin/DeleteHandlingStrategy.java
+++ b/main/java/io/github/azagniotov/stubby4j/handlers/strategy/admin/DeleteHandlingStrategy.java
@@ -3,6 +3,7 @@ package io.github.azagniotov.stubby4j.handlers.strategy.admin;
 import io.github.azagniotov.stubby4j.handlers.AdminPortalHandler;
 import io.github.azagniotov.stubby4j.stubs.StubRepository;
 import io.github.azagniotov.stubby4j.utils.HandlerUtils;
+import io.github.azagniotov.stubby4j.utils.StringUtils;
 import org.eclipse.jetty.http.HttpStatus;
 
 import javax.servlet.http.HttpServletRequest;
@@ -21,17 +22,32 @@ public class DeleteHandlingStrategy implements AdminResponseHandlingStrategy {
         }
 
         final int contextPathLength = AdminPortalHandler.ADMIN_ROOT.length();
-        final String pathInfoNoHeadingSlash = request.getRequestURI().substring(contextPathLength);
-        final int stubIndexToDelete = Integer.parseInt(pathInfoNoHeadingSlash);
+        final String lastUriPathSegment = request.getRequestURI().substring(contextPathLength);
 
-        if (!stubRepository.canMatchStubByIndex(stubIndexToDelete)) {
-            final String errorMessage = String.format("Stub request index#%s does not exist, cannot delete", stubIndexToDelete);
-            HandlerUtils.configureErrorResponse(response, HttpStatus.NO_CONTENT_204, errorMessage);
-            return;
+        // We are trying to delete a stub by ID, e.g.: DELETE localhost:8889/8
+        if (StringUtils.isNumeric(lastUriPathSegment)) {
+            final int stubIndexToDelete = Integer.parseInt(lastUriPathSegment);
+
+            if (!stubRepository.canMatchStubByIndex(stubIndexToDelete)) {
+                final String errorMessage = String.format("Stub request index#%s does not exist, cannot delete", stubIndexToDelete);
+                HandlerUtils.configureErrorResponse(response, HttpStatus.BAD_REQUEST_400, errorMessage);
+                return;
+            }
+
+            stubRepository.deleteStubByIndex(stubIndexToDelete);
+            response.setStatus(HttpStatus.OK_200);
+            response.getWriter().println(String.format("Stub request index#%s deleted successfully", stubIndexToDelete));
+        } else {
+            // We attempt to delete a stub by uuid as a fallback, e.g.: DELETE localhost:8889/9136d8b7-f7a7-478d-97a5-53292484aaf6
+            if (!stubRepository.canMatchStubByUuid(lastUriPathSegment)) {
+                final String errorMessage = String.format("Stub request uuid#%s does not exist, cannot delete", lastUriPathSegment);
+                HandlerUtils.configureErrorResponse(response, HttpStatus.BAD_REQUEST_400, errorMessage);
+                return;
+            }
+
+            stubRepository.deleteStubByUuid(lastUriPathSegment);
+            response.setStatus(HttpStatus.OK_200);
+            response.getWriter().println(String.format("Stub request uuid#%s deleted successfully", lastUriPathSegment));
         }
-
-        stubRepository.deleteStubByIndex(stubIndexToDelete);
-        response.setStatus(HttpStatus.OK_200);
-        response.getWriter().println(String.format("Stub request index#%s deleted successfully", stubIndexToDelete));
     }
 }

--- a/main/java/io/github/azagniotov/stubby4j/handlers/strategy/admin/PostHandlingStrategy.java
+++ b/main/java/io/github/azagniotov/stubby4j/handlers/strategy/admin/PostHandlingStrategy.java
@@ -4,7 +4,7 @@ import io.github.azagniotov.stubby4j.handlers.AdminPortalHandler;
 import io.github.azagniotov.stubby4j.stubs.StubRepository;
 import io.github.azagniotov.stubby4j.utils.HandlerUtils;
 import io.github.azagniotov.stubby4j.utils.StringUtils;
-import io.github.azagniotov.stubby4j.yaml.YAMLParser;
+import io.github.azagniotov.stubby4j.yaml.YamlParser;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 
@@ -28,7 +28,7 @@ public class PostHandlingStrategy implements AdminResponseHandlingStrategy {
             return;
         }
 
-        stubRepository.refreshStubsByPost(new YAMLParser(), post);
+        stubRepository.refreshStubsByPost(new YamlParser(), post);
 
         if (stubRepository.getStubs().size() == 1) {
             response.addHeader(HttpHeader.LOCATION.asString(), stubRepository.getOnlyStubRequestUrl());

--- a/main/java/io/github/azagniotov/stubby4j/server/StubbyManagerFactory.java
+++ b/main/java/io/github/azagniotov/stubby4j/server/StubbyManagerFactory.java
@@ -24,16 +24,15 @@ import io.github.azagniotov.stubby4j.cli.CommandLineInterpreter;
 import io.github.azagniotov.stubby4j.cli.EmptyLogger;
 import io.github.azagniotov.stubby4j.filesystem.ExternalFilesScanner;
 import io.github.azagniotov.stubby4j.filesystem.MainYamlScanner;
-import io.github.azagniotov.stubby4j.stubs.StubHttpLifecycle;
 import io.github.azagniotov.stubby4j.stubs.StubRepository;
 import io.github.azagniotov.stubby4j.utils.ObjectUtils;
+import io.github.azagniotov.stubby4j.yaml.YamlParseResultSet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.log.Log;
 
 import java.io.File;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 public class StubbyManagerFactory {
 
@@ -43,7 +42,7 @@ public class StubbyManagerFactory {
 
     public synchronized StubbyManager construct(final File configFile,
                                                 final Map<String, String> commandLineArgs,
-                                                final Future<List<StubHttpLifecycle>> stubLoadComputation) throws Exception {
+                                                final CompletableFuture<YamlParseResultSet> stubLoadComputation) throws Exception {
 
         // Commenting out the following line will configure Jetty for StdErrLog DEBUG level logging
         Log.setLog(new EmptyLogger());

--- a/main/java/io/github/azagniotov/stubby4j/stubs/RegexParser.java
+++ b/main/java/io/github/azagniotov/stubby4j/stubs/RegexParser.java
@@ -2,66 +2,146 @@ package io.github.azagniotov.stubby4j.stubs;
 
 
 import io.github.azagniotov.stubby4j.annotations.VisibleForTesting;
+import io.github.azagniotov.stubby4j.caching.Cache;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import static io.github.azagniotov.stubby4j.utils.StringUtils.buildToken;
-import static java.util.regex.Pattern.quote;
 
 enum RegexParser {
 
     INSTANCE;
 
-    @VisibleForTesting
-    static final Map<Integer, Pattern> STUBBED_VALUE_TO_REGEX_PATTERN = new ConcurrentHashMap<>();
+    // Pattern.MULTILINE changes the behavior of '^' and '$' characters by telling Java to accept the
+    // anchors '^' and '$' to match at the start and end of each line (otherwise they only match at the
+    // start/end of the entire string). In other words, if the string contains newlines, you can choose
+    // for '^' and '$' to match at the start and end of any logical line, not just the start and end of
+    // the whole string, by setting the MULTILINE flag.
+    //
+    // You need to make sure that you regex pattern covers both \r (carriage return) and \n (linefeed).
+    // It is achievable by using symbol '\s+', which covers both \r (carriage return) and \n (linefeed).
+    static final int[] REGEX_FLAGS = new int[]{Pattern.MULTILINE, Pattern.DOTALL};
 
-    // A very primitive way to test if string is *maybe* a regex pattern, instead of compiling a Pattern
+    // 7200 secs => 2 hours
+    private static final long CACHE_ENTRY_LIFETIME_SECONDS = 7200L;
+
     @VisibleForTesting
-    static final Pattern SPECIAL_REGEX_CHARS = Pattern.compile(String.format(".*([%s%s%s%s%s%s%s%s%s%s]).*",
-            quote("^"),
-            quote("$"),
-            quote("["),
-            quote("]"),
-            quote("{"),
-            quote("}"),
-            quote("*"),
-            quote("|"),
-            quote("\\"),
-            quote("?")));
+    static final Cache<Integer, Pattern> REGEX_PATTERN_CACHE = Cache.regexPatternCache(CACHE_ENTRY_LIFETIME_SECONDS);
+
+    /**
+     * ASCII character decimal values
+     * '$'    - 36
+     * '('    - 40
+     * ')'    - 41
+     * '*'    - 42
+     * '?'    - 63
+     * '['    - 91
+     * ']'    - 93
+     * '\'    - 92
+     * '^'    - 94
+     * '{'    - 123
+     * '|'    - 124
+     * '}'    - 125
+     */
+
+    @VisibleForTesting
+    static final char[] REGEX_CHARS = new char[]{'$', '(', ')', '*', '?', '[', ']', '\\', '^', '{', '|', '}'};
+
+    private static final boolean[] SPECIAL_CHARS;
+
+    static {
+        SPECIAL_CHARS = new boolean[127];
+        for (final char c : REGEX_CHARS) {
+            SPECIAL_CHARS[c] = true;
+        }
+    }
 
     void compilePatternAndCache(final String value) {
-        compilePatternAndCache(value, Pattern.MULTILINE);
+        int currentFlags = 0;
+        for (int flag : REGEX_FLAGS) {
+            compilePatternAndCache(value, currentFlags |= flag);
+        }
     }
 
     private void compilePatternAndCache(final String value, final int flags) {
         try {
-            if (SPECIAL_REGEX_CHARS.matcher(value).matches()) {
-                STUBBED_VALUE_TO_REGEX_PATTERN.computeIfAbsent(value.hashCode(), hashCode -> Pattern.compile(value, flags));
+            if (potentialRegex(value)) {
+                final int patternHashCodeRegexFlagKey = value.hashCode() + flags;
+                final Pattern computedPattern = Pattern.compile(value, flags);
+
+                REGEX_PATTERN_CACHE.putIfAbsent(patternHashCodeRegexFlagKey, computedPattern);
             }
         } catch (final PatternSyntaxException e) {
-            // We could not compile, probably because of some characters that are special for Pattern
-            compilePatternAndCache(value, Pattern.LITERAL | Pattern.MULTILINE);
+            // We could not compile the pattern, probably because of some unescaped
+            // characters that are special for regex, i.e.: JSON string literal
+            compilePatternAndCache(value, Pattern.LITERAL);
         }
     }
 
     boolean match(final String patternCandidate, final String subject, final String templateTokenName, final Map<String, String> regexGroups) {
-        // Pattern.MULTILINE changes the behavior of '^' and '$' characters,
-        // it does not mean that newline feeds and carriage return will be matched by default
-        // You need to make sure that you regex pattern covers both \r (carriage return) and \n (linefeed).
-        // It is achievable by using symbol '\s+' which covers both \r (carriage return) and \n (linefeed).
-        return match(patternCandidate, subject, templateTokenName, regexGroups, Pattern.MULTILINE);
+        int currentFlags = 0;
+        for (int flag : REGEX_FLAGS) {
+            if (match(patternCandidate, subject, templateTokenName, regexGroups, currentFlags |= flag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A very primitive way to test if string is *maybe* a regex pattern, instead of compiling a Pattern
+     *
+     * @param pattern to check for presence of regex special characters
+     */
+    static boolean potentialRegex(final String pattern) {
+        return potentialRegex(pattern, 2);
+    }
+
+    private static boolean potentialRegex(final String pattern, int threshold) {
+
+        char[] chars = pattern.toCharArray();
+
+        if (chars.length < 3) {
+            return false;
+        }
+
+        if (chars[0] == '^' || chars[chars.length - 1] == '$') {
+            return true;
+        }
+
+        for (final char currentChar : chars) {
+
+            if (threshold == 0) {
+                return true;
+            }
+
+            if ((currentChar >= 'A' && currentChar <= 'Z') || (currentChar >= 'a' && currentChar <= 'z')) {
+                continue;
+            }
+
+            if (currentChar - REGEX_CHARS[0] < 0 || currentChar > REGEX_CHARS[REGEX_CHARS.length - 1]) {
+                continue;
+            }
+
+            if (SPECIAL_CHARS[currentChar]) {
+                --threshold;
+            }
+        }
+
+        return threshold == 0;
     }
 
     private boolean match(final String patternCandidate, final String subject, final String templateTokenName, final Map<String, String> regexGroups, final int flags) {
         try {
-            final Pattern pattern = STUBBED_VALUE_TO_REGEX_PATTERN.computeIfAbsent(
-                    patternCandidate.hashCode(), hashCode -> Pattern.compile(patternCandidate, flags));
+            final int patternHashCodeRegexFlagKey = patternCandidate.hashCode() + flags;
+            final Pattern computedPattern = Pattern.compile(patternCandidate, flags);
 
-            final Matcher matcher = pattern.matcher(subject);
+            REGEX_PATTERN_CACHE.putIfAbsent(patternHashCodeRegexFlagKey, computedPattern);
+
+            final Matcher matcher = computedPattern.matcher(subject);
             final boolean isMatch = matcher.matches();
             if (isMatch) {
                 // group(0) holds the full regex matchStubByIndex
@@ -78,8 +158,9 @@ enum RegexParser {
             }
             return isMatch;
         } catch (final PatternSyntaxException e) {
-            // We could not compile, probably because of some characters that are special for Pattern
-            return match(patternCandidate, subject, templateTokenName, regexGroups, Pattern.LITERAL | Pattern.MULTILINE);
+            // We could not compile the pattern, probably because of some unescaped
+            // characters that are special for regex, i.e.: JSON string literal
+            return match(patternCandidate, subject, templateTokenName, regexGroups, Pattern.LITERAL);
         }
     }
 }

--- a/main/java/io/github/azagniotov/stubby4j/stubs/StubHttpLifecycle.java
+++ b/main/java/io/github/azagniotov/stubby4j/stubs/StubHttpLifecycle.java
@@ -26,6 +26,7 @@ public class StubHttpLifecycle implements ReflectableStub {
     private final String requestAsYAML;
     private final String responseAsYAML;
     private final String description;
+    private final String uuid;
 
     private StubHttpLifecycle(
             final StubRequest request,
@@ -33,13 +34,15 @@ public class StubHttpLifecycle implements ReflectableStub {
             final String requestAsYAML,
             final String responseAsYAML,
             final String completeYAML,
-            final String description) {
+            final String description,
+            final String uuid) {
         this.request = request;
         this.response = response;
         this.requestAsYAML = requestAsYAML;
         this.responseAsYAML = responseAsYAML;
         this.completeYAML = completeYAML;
         this.description = description;
+        this.uuid = uuid;
     }
 
     public StubRequest getRequest() {
@@ -115,11 +118,15 @@ public class StubHttpLifecycle implements ReflectableStub {
         return description;
     }
 
+    public String getUUID() {
+        return uuid;
+    }
+
     /**
      * Do not remove this method if your IDE complains that it is unused.
      * It is used by {@link ReflectionUtils} at runtime when fetching content for Ajax response
      */
-    public String getCompleteYAML() {
+    public String getCompleteYaml() {
         return completeYAML;
     }
 
@@ -185,6 +192,7 @@ public class StubHttpLifecycle implements ReflectableStub {
         private String requestAsYAML;
         private String responseAsYAML;
         private String description;
+        private String uuid;
 
         public Builder() {
             this.request = null;
@@ -193,6 +201,7 @@ public class StubHttpLifecycle implements ReflectableStub {
             this.requestAsYAML = null;
             this.responseAsYAML = null;
             this.description = null;
+            this.uuid = null;
         }
 
         public Builder withRequest(final StubRequest request) {
@@ -241,8 +250,22 @@ public class StubHttpLifecycle implements ReflectableStub {
             return this;
         }
 
+        public Builder withUUID(final String uuid) {
+            this.uuid = uuid;
+
+            return this;
+        }
+
         public StubHttpLifecycle build() {
-            final StubHttpLifecycle stubHttpLifecycle = new StubHttpLifecycle(request, response, requestAsYAML, responseAsYAML, completeYAML, description);
+            final StubHttpLifecycle stubHttpLifecycle =
+                    new StubHttpLifecycle(
+                            request,
+                            response,
+                            requestAsYAML,
+                            responseAsYAML,
+                            completeYAML,
+                            description,
+                            uuid);
 
             this.request = null;
             this.response = okResponse();
@@ -250,6 +273,7 @@ public class StubHttpLifecycle implements ReflectableStub {
             this.requestAsYAML = null;
             this.responseAsYAML = null;
             this.description = null;
+            this.uuid = null;
 
             return stubHttpLifecycle;
         }

--- a/main/java/io/github/azagniotov/stubby4j/utils/DateTimeUtils.java
+++ b/main/java/io/github/azagniotov/stubby4j/utils/DateTimeUtils.java
@@ -1,0 +1,20 @@
+package io.github.azagniotov.stubby4j.utils;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeUtils {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd HH:mm:ssZ")
+            .withZone(ZoneOffset.systemDefault());
+
+    public static String systemDefault() {
+        return DATE_TIME_FORMATTER.format(Instant.now());
+    }
+
+    public static String systemDefault(final long epochMilli) {
+        return DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(epochMilli));
+    }
+}

--- a/main/java/io/github/azagniotov/stubby4j/utils/HandlerUtils.java
+++ b/main/java/io/github/azagniotov/stubby4j/utils/HandlerUtils.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Date;
 
 import static io.github.azagniotov.stubby4j.utils.StringUtils.pluralize;
 import static java.util.concurrent.TimeUnit.DAYS;
@@ -73,7 +72,7 @@ public final class HandlerUtils {
     public static void setResponseMainHeaders(final HttpServletResponse response) {
         response.setCharacterEncoding(StringUtils.UTF_8);
         response.setHeader(HttpHeader.SERVER.asString(), HandlerUtils.constructHeaderServerName());
-        response.setHeader(HttpHeader.DATE.asString(), new Date().toString());
+        response.setHeader(HttpHeader.DATE.asString(), DateTimeUtils.systemDefault());
         response.setHeader(HttpHeader.CONTENT_TYPE.asString(), "text/html;charset=UTF-8");
         response.setHeader(HttpHeader.CACHE_CONTROL.asString(), "no-cache, no-stage, must-revalidate"); // HTTP 1.1.
         response.setHeader(HttpHeader.PRAGMA.asString(), "no-cache"); // HTTP 1.0.

--- a/main/java/io/github/azagniotov/stubby4j/utils/JarUtils.java
+++ b/main/java/io/github/azagniotov/stubby4j/utils/JarUtils.java
@@ -41,6 +41,6 @@ public final class JarUtils {
             //Do nothing
         }
 
-        return "Thu, 01 Jan 1970 00:00:00 GMT";
+        return DateTimeUtils.systemDefault();
     }
 }

--- a/main/java/io/github/azagniotov/stubby4j/utils/StringUtils.java
+++ b/main/java/io/github/azagniotov/stubby4j/utils/StringUtils.java
@@ -125,6 +125,15 @@ public final class StringUtils {
         return target.contains(TEMPLATE_TOKEN_LEFT);
     }
 
+    public static boolean isNumeric(final String target) {
+        for (char c : target.toCharArray()) {
+            if (!Character.isDigit(c)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public static String escapeHtmlEntities(final String toBeEscaped) {
         return toBeEscaped.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
     }

--- a/main/java/io/github/azagniotov/stubby4j/yaml/ConfigurableYAMLProperty.java
+++ b/main/java/io/github/azagniotov/stubby4j/yaml/ConfigurableYAMLProperty.java
@@ -21,7 +21,8 @@ public enum ConfigurableYAMLProperty {
     RESPONSE,
     STATUS,
     URL,
-    DESCRIPTION;
+    DESCRIPTION,
+    UUID;
 
     private static final Map<String, ConfigurableYAMLProperty> PROPERTY_NAME_TO_ENUM_MEMBER;
 

--- a/main/java/io/github/azagniotov/stubby4j/yaml/YamlParseResultSet.java
+++ b/main/java/io/github/azagniotov/stubby4j/yaml/YamlParseResultSet.java
@@ -1,0 +1,27 @@
+package io.github.azagniotov.stubby4j.yaml;
+
+import io.github.azagniotov.stubby4j.stubs.StubHttpLifecycle;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class YamlParseResultSet {
+
+    private final List<StubHttpLifecycle> stubs;
+    private final Map<String, StubHttpLifecycle> uuidToStubs;
+
+    public YamlParseResultSet(final List<StubHttpLifecycle> stubs, final Map<String, StubHttpLifecycle> uuidToStubs) {
+        this.stubs = stubs;
+        this.uuidToStubs = uuidToStubs;
+    }
+
+    public List<StubHttpLifecycle> getStubs() {
+        return new LinkedList<>(stubs);
+    }
+
+    public Map<String, StubHttpLifecycle> getUuidToStubs() {
+        return new HashMap<>(uuidToStubs);
+    }
+}

--- a/main/resources/ui/html/_popup_generic.html
+++ b/main/resources/ui/html/_popup_generic.html
@@ -1,21 +1,21 @@
 <div id="overlay"></div>
 <div id="popup-window" class="global-styles border-thickness-plus-translucency border-radius-26px box-shadow-4px">
-   <div id="popup-drag-handle">
-      <div id="popup-title"><span class="drag">x-stubby-resource-id=%s, <b class="drag">%s</b></span></div>
-      <a id="close-x" href="javascript:void(0)">x</a>
-   </div>
-   <div id="popup-body">
-      <div id="popup-content" class="border-radius-7px">
-         <b>
-            <pre><code id="ajax-response">%s</code></pre>
-         </b>
-      </div>
-      <br>
-      <div id="popup-footer">
-         <div id="close-dialog-btn-wrapper">
-            <input id="close-dialog-btn" class="border-radius-5px box-shadow-2px" type="button" value="Close">
-         </div>
-         <div id="popup-resize-handle">|||||</div>
-      </div>
-   </div>
+    <div id="popup-drag-handle">
+        <div id="popup-title"><span class="drag">{resource-id=%s} {uuid=%s}</span></div>
+        <a id="close-x" href="javascript:void(0)">x</a>
+    </div>
+    <div id="popup-body">
+        <div id="popup-content" class="border-radius-7px">
+            <b>
+                <pre><code id="ajax-response">%s</code></pre>
+            </b>
+        </div>
+        <br>
+        <div id="popup-footer">
+            <div id="close-dialog-btn-wrapper">
+                <input id="close-dialog-btn" class="border-radius-5px box-shadow-2px" type="button" value="Close">
+            </div>
+            <div id="popup-resize-handle">|||||</div>
+        </div>
+    </div>
 </div>

--- a/main/resources/ui/js/main.js
+++ b/main/resources/ui/js/main.js
@@ -9,7 +9,7 @@ $(function () {
       bindLinks();
       var checkForStatsTimeout = setTimeout(function () {
          checkForStats();
-      }, 1000);
+      }, 3000);
 
       function checkForStats() {
          var statsPresent = false;
@@ -27,7 +27,7 @@ $(function () {
                } else {
                   checkForStatsTimeout = setTimeout(function () {
                      checkForStats();
-                  }, 1000);
+                  }, 3000);
                }
             },
             function error(status, statusText, responseText) {

--- a/unit/java/io/github/azagniotov/stubby4j/handlers/AjaxResourceContentHandlerTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/handlers/AjaxResourceContentHandlerTest.java
@@ -95,7 +95,7 @@ public class AjaxResourceContentHandlerTest {
         spyAjaxResourceContentHandler.handle(requestURI, mockRequest, mockHttpServletRequest, mockHttpServletResponse);
 
         verify(spyAjaxResourceContentHandler).throwErrorOnNonExistentResourceIndex(any(HttpServletResponse.class), stubIndexCaptor.capture());
-        verify(spyAjaxResourceContentHandler, times(1)).renderAjaxResponseContent(any(HttpServletResponse.class), stubTypeCaptor.capture(), fieldCaptor.capture(), any(StubHttpLifecycle.class));
+        verify(spyAjaxResourceContentHandler).renderAjaxResponseContent(any(HttpServletResponse.class), stubTypeCaptor.capture(), fieldCaptor.capture(), any(StubHttpLifecycle.class));
         verify(spyAjaxResourceContentHandler, never()).renderAjaxResponseContent(any(HttpServletResponse.class), anyInt(), anyString(), any(StubHttpLifecycle.class));
 
         assertThat(stubIndexCaptor.getValue()).isEqualTo(5);
@@ -114,7 +114,7 @@ public class AjaxResourceContentHandlerTest {
         spyAjaxResourceContentHandler.handle(requestURI, mockRequest, mockHttpServletRequest, mockHttpServletResponse);
 
         verify(spyAjaxResourceContentHandler).throwErrorOnNonExistentResourceIndex(any(HttpServletResponse.class), stubIndexCaptor.capture());
-        verify(spyAjaxResourceContentHandler, times(1)).renderAjaxResponseContent(any(HttpServletResponse.class), stubTypeCaptor.capture(), fieldCaptor.capture(), any(StubHttpLifecycle.class));
+        verify(spyAjaxResourceContentHandler).renderAjaxResponseContent(any(HttpServletResponse.class), stubTypeCaptor.capture(), fieldCaptor.capture(), any(StubHttpLifecycle.class));
         verify(spyAjaxResourceContentHandler, never()).renderAjaxResponseContent(any(HttpServletResponse.class), anyInt(), anyString(), any(StubHttpLifecycle.class));
 
         assertThat(stubIndexCaptor.getValue()).isEqualTo(15);
@@ -133,7 +133,7 @@ public class AjaxResourceContentHandlerTest {
         spyAjaxResourceContentHandler.handle(requestURI, mockRequest, mockHttpServletRequest, mockHttpServletResponse);
 
         verify(spyAjaxResourceContentHandler).throwErrorOnNonExistentResourceIndex(any(HttpServletResponse.class), stubIndexCaptor.capture());
-        verify(spyAjaxResourceContentHandler, times(1)).renderAjaxResponseContent(any(HttpServletResponse.class), responseSequenceCaptor.capture(), fieldCaptor.capture(), any(StubHttpLifecycle.class));
+        verify(spyAjaxResourceContentHandler).renderAjaxResponseContent(any(HttpServletResponse.class), responseSequenceCaptor.capture(), fieldCaptor.capture(), any(StubHttpLifecycle.class));
         verify(spyAjaxResourceContentHandler, never()).renderAjaxResponseContent(any(HttpServletResponse.class), any(StubTypes.class), anyString(), any(StubHttpLifecycle.class));
 
         assertThat(stubIndexCaptor.getValue()).isEqualTo(15);
@@ -167,8 +167,8 @@ public class AjaxResourceContentHandlerTest {
 
         spyAjaxResourceContentHandler.handle(requestURI, mockRequest, mockHttpServletRequest, mockHttpServletResponse);
 
-        verify(spyAjaxResourceContentHandler, times(1)).throwErrorOnNonExistentResourceIndex(any(HttpServletResponse.class), anyInt());
-        verify(mockPrintWriter, times(1)).println("Could not fetch the content for stub type: WRONG-STUB-TYPE");
+        verify(spyAjaxResourceContentHandler).throwErrorOnNonExistentResourceIndex(any(HttpServletResponse.class), anyInt());
+        verify(mockPrintWriter).println("Could not fetch the content for stub type: WRONG-STUB-TYPE");
 
         verify(spyAjaxResourceContentHandler, never()).renderAjaxResponseContent(any(HttpServletResponse.class), any(StubTypes.class), anyString(), any(StubHttpLifecycle.class));
         verify(spyAjaxResourceContentHandler, never()).renderAjaxResponseContent(any(HttpServletResponse.class), anyInt(), anyString(), any(StubHttpLifecycle.class));

--- a/unit/java/io/github/azagniotov/stubby4j/handlers/StubsPortalHandlerTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/handlers/StubsPortalHandlerTest.java
@@ -78,7 +78,7 @@ public class StubsPortalHandlerTest {
 
         setUpStubSearchMockExpectations(requestPathInfo);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.NOT_FOUND_404);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.NOT_FOUND_404);
         verify(mockHttpServletResponse, never()).setStatus(HttpStatus.OK_200);
     }
 
@@ -98,7 +98,7 @@ public class StubsPortalHandlerTest {
 
         setUpStubSearchMockExpectations(requestPathInfo);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.NOT_FOUND_404);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.NOT_FOUND_404);
         verify(mockHttpServletResponse, never()).setStatus(HttpStatus.OK_200);
     }
 
@@ -114,7 +114,7 @@ public class StubsPortalHandlerTest {
         setUpStubSearchMockExpectations(requestPathInfo);
 
         verify(mockHttpServletResponse, never()).setStatus(HttpStatus.BAD_REQUEST_400);
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.OK_200);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.OK_200);
     }
 
     @Test
@@ -132,7 +132,7 @@ public class StubsPortalHandlerTest {
         setUpStubSearchMockExpectations(requestPathInfo);
 
         verify(mockHttpServletResponse, never()).setStatus(HttpStatus.BAD_REQUEST_400);
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.OK_200);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.OK_200);
     }
 
     @Test
@@ -147,7 +147,7 @@ public class StubsPortalHandlerTest {
 
         setUpStubSearchMockExpectations(requestPathInfo);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.OK_200);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.OK_200);
     }
 
     @Test
@@ -161,8 +161,8 @@ public class StubsPortalHandlerTest {
 
         setUpStubSearchMockExpectations(requestPathInfo);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.UNAUTHORIZED_401);
-        verify(mockHttpServletResponse, times(1)).sendError(HttpStatus.UNAUTHORIZED_401, NO_AUTHORIZATION_HEADER);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.UNAUTHORIZED_401);
+        verify(mockHttpServletResponse).sendError(HttpStatus.UNAUTHORIZED_401, NO_AUTHORIZATION_HEADER);
         verify(mockHttpServletResponse, never()).setStatus(HttpStatus.OK_200);
     }
 
@@ -177,8 +177,8 @@ public class StubsPortalHandlerTest {
 
         setUpStubSearchMockExpectations(requestPathInfo);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.UNAUTHORIZED_401);
-        verify(mockHttpServletResponse, times(1)).sendError(HttpStatus.UNAUTHORIZED_401, UnauthorizedResponseHandlingStrategy.NO_AUTHORIZATION_HEADER);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.UNAUTHORIZED_401);
+        verify(mockHttpServletResponse).sendError(HttpStatus.UNAUTHORIZED_401, UnauthorizedResponseHandlingStrategy.NO_AUTHORIZATION_HEADER);
         verify(mockHttpServletResponse, never()).setStatus(HttpStatus.OK_200);
     }
 
@@ -193,8 +193,8 @@ public class StubsPortalHandlerTest {
 
         setUpStubSearchMockExpectations(requestPathInfo);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.UNAUTHORIZED_401);
-        verify(mockHttpServletResponse, times(1)).sendError(HttpStatus.UNAUTHORIZED_401, UnauthorizedResponseHandlingStrategy.NO_AUTHORIZATION_HEADER);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.UNAUTHORIZED_401);
+        verify(mockHttpServletResponse).sendError(HttpStatus.UNAUTHORIZED_401, UnauthorizedResponseHandlingStrategy.NO_AUTHORIZATION_HEADER);
         verify(mockHttpServletResponse, never()).setStatus(HttpStatus.OK_200);
     }
 
@@ -212,7 +212,7 @@ public class StubsPortalHandlerTest {
 
         setUpStubSearchMockExpectations(requestPathInfo);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.OK_200);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.OK_200);
     }
 
     @Test
@@ -230,7 +230,7 @@ public class StubsPortalHandlerTest {
         setUpStubSearchMockExpectations(requestPathInfo);
 
         verify(mockHttpServletResponse, never()).setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.OK_200);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.OK_200);
     }
 
     @Test
@@ -244,7 +244,7 @@ public class StubsPortalHandlerTest {
 
         setUpStubSearchMockExpectations(requestPathInfo);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
         verify(mockHttpServletResponse, never()).setStatus(HttpStatus.OK_200);
         verify(mockPrintWriter, never()).println(SOME_RESULTS_MESSAGE);
     }

--- a/unit/java/io/github/azagniotov/stubby4j/handlers/strategy/DefaultResponseHandlingStrategyTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/handlers/strategy/DefaultResponseHandlingStrategyTest.java
@@ -79,7 +79,7 @@ public class DefaultResponseHandlingStrategyTest {
 
         defaultResponseHandlingStrategy.handle(mockHttpServletResponse, mockAssertionRequest);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.OK_200);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.OK_200);
         verifyMainHeaders(mockHttpServletResponse);
     }
 
@@ -92,7 +92,7 @@ public class DefaultResponseHandlingStrategyTest {
 
         defaultResponseHandlingStrategy.handle(mockHttpServletResponse, mockAssertionRequest);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.OK_200);
+        verify(mockHttpServletResponse).setStatus(HttpStatus.OK_200);
         verifyMainHeaders(mockHttpServletResponse);
     }
 
@@ -130,7 +130,7 @@ public class DefaultResponseHandlingStrategyTest {
 
         defaultResponseHandlingStrategy.handle(mockHttpServletResponse, mockAssertionRequest);
 
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.LOCATION.asString(), headerValuePrefix + nonce);
+        verify(mockHttpServletResponse).setHeader(HttpHeader.LOCATION.asString(), headerValuePrefix + nonce);
         verifyMainHeaders(mockHttpServletResponse);
     }
 
@@ -151,8 +151,8 @@ public class DefaultResponseHandlingStrategyTest {
 
         ArgumentCaptor<byte[]> responseCaptor = ArgumentCaptor.forClass(byte[].class);
 
-        verify(mockHttpServletResponse, times(1)).getOutputStream();
-        verify(mockOutputStream, times(1)).write(responseCaptor.capture());
+        verify(mockHttpServletResponse).getOutputStream();
+        verify(mockOutputStream).write(responseCaptor.capture());
 
         String response = new String(responseCaptor.getValue(), StringUtils.charsetUTF8());
 
@@ -161,10 +161,10 @@ public class DefaultResponseHandlingStrategyTest {
     }
 
     private void verifyMainHeaders(final HttpServletResponse mockHttpServletResponse) throws Exception {
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.SERVER.asString(), HandlerUtils.constructHeaderServerName());
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.CONTENT_TYPE.asString(), "text/html;charset=UTF-8");
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.CACHE_CONTROL.asString(), "no-cache, no-stage, must-revalidate");
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.PRAGMA.asString(), "no-cache");
-        verify(mockHttpServletResponse, times(1)).setDateHeader(HttpHeader.EXPIRES.asString(), 0);
+        verify(mockHttpServletResponse).setHeader(HttpHeader.SERVER.asString(), HandlerUtils.constructHeaderServerName());
+        verify(mockHttpServletResponse).setHeader(HttpHeader.CONTENT_TYPE.asString(), "text/html;charset=UTF-8");
+        verify(mockHttpServletResponse).setHeader(HttpHeader.CACHE_CONTROL.asString(), "no-cache, no-stage, must-revalidate");
+        verify(mockHttpServletResponse).setHeader(HttpHeader.PRAGMA.asString(), "no-cache");
+        verify(mockHttpServletResponse).setDateHeader(HttpHeader.EXPIRES.asString(), 0);
     }
 }

--- a/unit/java/io/github/azagniotov/stubby4j/handlers/strategy/RedirectResponseHandlingStrategyTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/handlers/strategy/RedirectResponseHandlingStrategyTest.java
@@ -55,9 +55,9 @@ public class RedirectResponseHandlingStrategyTest {
 
         redirectResponseHandlingStrategy.handle(mockHttpServletResponse, mockAssertionRequest);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.MOVED_TEMPORARILY_302);
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.LOCATION.asString(), mockStubResponse.getHeaders().get("location"));
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.CONNECTION.asString(), "close");
+        verify(mockHttpServletResponse).setStatus(HttpStatus.MOVED_TEMPORARILY_302);
+        verify(mockHttpServletResponse).setHeader(HttpHeader.LOCATION.asString(), mockStubResponse.getHeaders().get("location"));
+        verify(mockHttpServletResponse).setHeader(HttpHeader.CONNECTION.asString(), "close");
         verifyMainHeaders(mockHttpServletResponse);
     }
 
@@ -67,9 +67,9 @@ public class RedirectResponseHandlingStrategyTest {
 
         redirectResponseHandlingStrategy.handle(mockHttpServletResponse, mockAssertionRequest);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.MOVED_PERMANENTLY_301);
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.LOCATION.asString(), mockStubResponse.getHeaders().get("location"));
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.CONNECTION.asString(), "close");
+        verify(mockHttpServletResponse).setStatus(HttpStatus.MOVED_PERMANENTLY_301);
+        verify(mockHttpServletResponse).setHeader(HttpHeader.LOCATION.asString(), mockStubResponse.getHeaders().get("location"));
+        verify(mockHttpServletResponse).setHeader(HttpHeader.CONNECTION.asString(), "close");
         verifyMainHeaders(mockHttpServletResponse);
     }
 
@@ -80,9 +80,9 @@ public class RedirectResponseHandlingStrategyTest {
 
         redirectResponseHandlingStrategy.handle(mockHttpServletResponse, mockAssertionRequest);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.MOVED_PERMANENTLY_301);
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.LOCATION.asString(), mockStubResponse.getHeaders().get("location"));
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.CONNECTION.asString(), "close");
+        verify(mockHttpServletResponse).setStatus(HttpStatus.MOVED_PERMANENTLY_301);
+        verify(mockHttpServletResponse).setHeader(HttpHeader.LOCATION.asString(), mockStubResponse.getHeaders().get("location"));
+        verify(mockHttpServletResponse).setHeader(HttpHeader.CONNECTION.asString(), "close");
         verifyMainHeaders(mockHttpServletResponse);
     }
 
@@ -101,18 +101,18 @@ public class RedirectResponseHandlingStrategyTest {
 
         redirectResponseHandlingStrategy.handle(mockHttpServletResponse, mockAssertionRequest);
 
-        verify(mockHttpServletResponse, times(1)).setStatus(HttpStatus.MOVED_TEMPORARILY_302);
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.LOCATION.asString(), "https://test.com/auth");
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.CONNECTION.asString(), "close");
+        verify(mockHttpServletResponse).setStatus(HttpStatus.MOVED_TEMPORARILY_302);
+        verify(mockHttpServletResponse).setHeader(HttpHeader.LOCATION.asString(), "https://test.com/auth");
+        verify(mockHttpServletResponse).setHeader(HttpHeader.CONNECTION.asString(), "close");
         verifyMainHeaders(mockHttpServletResponse);
 
     }
 
     private void verifyMainHeaders(final HttpServletResponse mockHttpServletResponse) throws Exception {
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.SERVER.asString(), HandlerUtils.constructHeaderServerName());
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.CONTENT_TYPE.asString(), "text/html;charset=UTF-8");
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.CACHE_CONTROL.asString(), "no-cache, no-stage, must-revalidate");
-        verify(mockHttpServletResponse, times(1)).setHeader(HttpHeader.PRAGMA.asString(), "no-cache");
-        verify(mockHttpServletResponse, times(1)).setDateHeader(HttpHeader.EXPIRES.asString(), 0);
+        verify(mockHttpServletResponse).setHeader(HttpHeader.SERVER.asString(), HandlerUtils.constructHeaderServerName());
+        verify(mockHttpServletResponse).setHeader(HttpHeader.CONTENT_TYPE.asString(), "text/html;charset=UTF-8");
+        verify(mockHttpServletResponse).setHeader(HttpHeader.CACHE_CONTROL.asString(), "no-cache, no-stage, must-revalidate");
+        verify(mockHttpServletResponse).setHeader(HttpHeader.PRAGMA.asString(), "no-cache");
+        verify(mockHttpServletResponse).setDateHeader(HttpHeader.EXPIRES.asString(), 0);
     }
 }

--- a/unit/java/io/github/azagniotov/stubby4j/stubs/RegexParserTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/stubs/RegexParserTest.java
@@ -2,24 +2,83 @@ package io.github.azagniotov.stubby4j.stubs;
 
 import org.junit.Test;
 
-import java.util.regex.Pattern;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.github.azagniotov.stubby4j.stubs.RegexParser.REGEX_CHARS;
+import static io.github.azagniotov.stubby4j.utils.FileUtils.BR;
 
 
 public class RegexParserTest {
 
     @Test
     public void shouldDetermineStringAsPotentialRegexPatterns() throws Exception {
-        final Pattern pattern = RegexParser.SPECIAL_REGEX_CHARS;
 
-        assertThat(pattern.matcher("Hello^").matches()).isTrue();
-        assertThat(pattern.matcher("[Array]").matches()).isTrue();
-        assertThat(pattern.matcher("{JsonObject}").matches()).isTrue();
-        assertThat(pattern.matcher("{JsonObject: [Array]}").matches()).isTrue();
-        assertThat(pattern.matcher("This|That").matches()).isTrue();
-        assertThat(pattern.matcher("I have a lot of $, how about you?").matches()).isTrue();
-        assertThat(pattern.matcher("I have a lot of, how about you?").matches()).isTrue();
-        assertThat(pattern.matcher("^[a-zA-Z]$").matches()).isTrue();
+        assertThat(RegexParser.potentialRegex("[Hello^]")).isTrue();
+        assertThat(RegexParser.potentialRegex("[Array]")).isTrue();
+        assertThat(RegexParser.potentialRegex("{JsonObject}")).isTrue();
+        assertThat(RegexParser.potentialRegex("{JsonObject: [Array]}")).isTrue();
+        assertThat(RegexParser.potentialRegex("This|That$")).isTrue();
+        assertThat(RegexParser.potentialRegex("I have a lot of $, how about you?")).isTrue();
+        assertThat(RegexParser.potentialRegex("^I have a lot of, how about you?")).isTrue();
+        assertThat(RegexParser.potentialRegex("^[a-zA-Z]$")).isTrue();
+        assertThat(RegexParser.potentialRegex("^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")).isTrue();
+        assertThat(RegexParser.potentialRegex("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$")).isTrue();
+        assertThat(RegexParser.potentialRegex("^\\\\")).isTrue();
+
+        assertThat(RegexParser.potentialRegex("!\"~")).isFalse();
+        assertThat(RegexParser.potentialRegex("^\\")).isFalse();
+        assertThat(RegexParser.potentialRegex("**")).isFalse();
+        assertThat(RegexParser.potentialRegex("()")).isFalse();
+        assertThat(RegexParser.potentialRegex("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")).isFalse();
+        assertThat(RegexParser.potentialRegex("")).isFalse();
+        assertThat(RegexParser.potentialRegex(")")).isFalse();
+        assertThat(RegexParser.potentialRegex(" ")).isFalse();
+        assertThat(RegexParser.potentialRegex("^")).isFalse();
+        assertThat(RegexParser.potentialRegex("\\")).isFalse();
+        assertThat(RegexParser.potentialRegex("////////")).isFalse();
+        assertThat(RegexParser.potentialRegex("<A>")).isFalse();
+        assertThat(RegexParser.potentialRegex("abcdeABCDE")).isFalse();
+        assertThat(RegexParser.potentialRegex(Character.toString((char) (REGEX_CHARS[0] - 1)))).isFalse();
+        assertThat(RegexParser.potentialRegex(Character.toString((char) (REGEX_CHARS[REGEX_CHARS.length - 1] + 1)))).isFalse();
+    }
+
+    @Test
+    public void shouldNotMatchWhenRegexPatternWithSyntaxError() throws Exception {
+        final String patternWithSyntaxError = "^abc[xyz{*";
+        boolean match = RegexParser.INSTANCE.match(patternWithSyntaxError, "someStringToMatch", "templateTokenName", new HashMap<>());
+
+        assertThat(match).isFalse();
+    }
+
+    @Test
+    public void shouldMatchSubjectWithMultiline() throws Exception {
+        final String testSubject =
+                "Biggest tech companies in the world by their market value as of 2018:" + BR +
+                        "Apple: $741.8 billion. In 2014, Apple, Inc. introduced a programming language called Swift." + BR +
+                        "In 2015, the company made Swift open-source, which allowed non-Apple developers to work " +
+                        "on the project." + BR + "Record-breaking three-day sales of 13 million units of the company’s " +
+                        "iPhone 6s and iPhone 6s Plus were announced in October 2015." + BR + BR +
+                        "Alphabet: $367.6 billion. In October 2015, Google restructured the company so that Alphabet, Inc." + BR +
+                        "became the parent company under which Google operates. Alphabet owns all of Google's side projects," + BR +
+                        "such as life-extension company Calico, innovative technology developer Google X, high-speed Internet" + BR +
+                        "provider Fiber and Google's smart home project Nest.";
+
+        final String regexPattern = "(.*)\\s+Apple:\\s+(.*)\\s+Alphabet:\\s+(.*)";
+
+        final Map<String, String> regexGroups = new HashMap<>();
+        boolean match = RegexParser.INSTANCE.match(regexPattern, testSubject, "token", regexGroups);
+
+        assertThat(match).isTrue();
+        assertThat(regexGroups.get("token.1").trim()).isEqualTo("Biggest tech companies in the world by their market value as of 2018:");
+        assertThat(regexGroups.get("token.2").trim()).isEqualTo("$741.8 billion. In 2014, Apple, Inc. introduced a programming language called Swift." + BR +
+                "In 2015, the company made Swift open-source, which allowed non-Apple developers to work " +
+                "on the project." + BR + "Record-breaking three-day sales of 13 million units of the company’s " +
+                "iPhone 6s and iPhone 6s Plus were announced in October 2015.");
+        assertThat(regexGroups.get("token.3").trim()).isEqualTo("$367.6 billion. In October 2015, Google restructured the company so that Alphabet, Inc." + BR +
+                "became the parent company under which Google operates. Alphabet owns all of Google's side projects," + BR +
+                "such as life-extension company Calico, innovative technology developer Google X, high-speed Internet" + BR +
+                "provider Fiber and Google's smart home project Nest.");
     }
 }

--- a/unit/java/io/github/azagniotov/stubby4j/stubs/StubHttpLifecycleBuilderTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/stubs/StubHttpLifecycleBuilderTest.java
@@ -236,11 +236,11 @@ public class StubHttpLifecycleBuilderTest {
 
         spyStubbedStubHttpLifecycle.isIncomingRequestUnauthorized(spyAssertingStubHttpLifecycle);
 
-        verify(spyAssertingStubHttpLifecycle, times(1)).getRawHeaderAuthorization();
+        verify(spyAssertingStubHttpLifecycle).getRawHeaderAuthorization();
         verify(spyAssertingStubHttpLifecycle, never()).getStubbedHeaderAuthorization(any(StubbableAuthorizationType.class));
 
         verify(spyStubbedStubHttpLifecycle, never()).getRawHeaderAuthorization();
-        verify(spyStubbedStubHttpLifecycle, times(1)).getStubbedHeaderAuthorization(StubbableAuthorizationType.BASIC);
+        verify(spyStubbedStubHttpLifecycle).getStubbedHeaderAuthorization(StubbableAuthorizationType.BASIC);
     }
 
     @Test
@@ -264,11 +264,11 @@ public class StubHttpLifecycleBuilderTest {
 
         spyStubbedStubHttpLifecycle.isIncomingRequestUnauthorized(spyAssertingStubHttpLifecycle);
 
-        verify(spyAssertingStubHttpLifecycle, times(1)).getRawHeaderAuthorization();
+        verify(spyAssertingStubHttpLifecycle).getRawHeaderAuthorization();
         verify(spyAssertingStubHttpLifecycle, never()).getStubbedHeaderAuthorization(any(StubbableAuthorizationType.class));
 
         verify(spyStubbedStubHttpLifecycle, never()).getRawHeaderAuthorization();
-        verify(spyStubbedStubHttpLifecycle, times(1)).getStubbedHeaderAuthorization(StubbableAuthorizationType.BASIC);
+        verify(spyStubbedStubHttpLifecycle).getStubbedHeaderAuthorization(StubbableAuthorizationType.BASIC);
     }
 
     @Test
@@ -292,11 +292,11 @@ public class StubHttpLifecycleBuilderTest {
 
         spyStubbedStubHttpLifecycle.isIncomingRequestUnauthorized(spyAssertingStubHttpLifecycle);
 
-        verify(spyAssertingStubHttpLifecycle, times(1)).getRawHeaderAuthorization();
+        verify(spyAssertingStubHttpLifecycle).getRawHeaderAuthorization();
         verify(spyAssertingStubHttpLifecycle, never()).getStubbedHeaderAuthorization(any(StubbableAuthorizationType.class));
 
         verify(spyStubbedStubHttpLifecycle, never()).getRawHeaderAuthorization();
-        verify(spyStubbedStubHttpLifecycle, times(1)).getStubbedHeaderAuthorization(StubbableAuthorizationType.BEARER);
+        verify(spyStubbedStubHttpLifecycle).getStubbedHeaderAuthorization(StubbableAuthorizationType.BEARER);
     }
 
     @Test
@@ -322,11 +322,11 @@ public class StubHttpLifecycleBuilderTest {
 
         spyStubbedStubHttpLifecycle.isIncomingRequestUnauthorized(spyAssertingStubHttpLifecycle);
 
-        verify(spyAssertingStubHttpLifecycle, times(1)).getRawHeaderAuthorization();
+        verify(spyAssertingStubHttpLifecycle).getRawHeaderAuthorization();
         verify(spyAssertingStubHttpLifecycle, never()).getStubbedHeaderAuthorization(any(StubbableAuthorizationType.class));
 
         verify(spyStubbedStubHttpLifecycle, never()).getRawHeaderAuthorization();
-        verify(spyStubbedStubHttpLifecycle, times(1)).getStubbedHeaderAuthorization(StubbableAuthorizationType.BEARER);
+        verify(spyStubbedStubHttpLifecycle).getStubbedHeaderAuthorization(StubbableAuthorizationType.BEARER);
     }
 
     @Test
@@ -350,11 +350,11 @@ public class StubHttpLifecycleBuilderTest {
 
         spyStubbedStubHttpLifecycle.isIncomingRequestUnauthorized(spyAssertingStubHttpLifecycle);
 
-        verify(spyAssertingStubHttpLifecycle, times(1)).getRawHeaderAuthorization();
+        verify(spyAssertingStubHttpLifecycle).getRawHeaderAuthorization();
         verify(spyAssertingStubHttpLifecycle, never()).getStubbedHeaderAuthorization(any(StubbableAuthorizationType.class));
 
         verify(spyStubbedStubHttpLifecycle, never()).getRawHeaderAuthorization();
-        verify(spyStubbedStubHttpLifecycle, times(1)).getStubbedHeaderAuthorization(StubbableAuthorizationType.BEARER);
+        verify(spyStubbedStubHttpLifecycle).getStubbedHeaderAuthorization(StubbableAuthorizationType.BEARER);
     }
 
     @Test

--- a/unit/java/io/github/azagniotov/stubby4j/stubs/StubMatcherTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/stubs/StubMatcherTest.java
@@ -269,6 +269,146 @@ public class StubMatcherTest {
     }
 
     @Test
+    public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentXmlWithAttributes() {
+
+        final String stubbedXml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<person xmlns=\"http://www.your.example.com/xml/person\">\n" +
+                        "     <VocabularyElement id=\"urn:epc:idpat:sgtin:0652642.107340\">\n" +
+                        "         <attribute id=\"urn:epcglobal:product:drugName\">Piramidon</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:manufacturer\">Generic Pharma Co.</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:dosageForm\">CAPSULE</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:strength\">125 mg</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:containerSize\">100</attribute>\n" +
+                        "    </VocabularyElement>" +
+                        "    <name>Rob</name>\n" +
+                        "    <age>37</age>\n" +
+                        "    <!--\n" +
+                        "      Hello,\n" +
+                        "         I am a multi-line XML comment\n" +
+                        "         <staticText>\n" +
+                        "            <reportElement x=\"180\" y=\"0\" width=\"200\" height=\"20\"/>\n" +
+                        "            <text><![CDATA[Hello World!]]></text>\n" +
+                        "          </staticText>\n" +
+                        "      -->" +
+                        "    <homecity xmlns=\"http://www.my.example.com/xml/cities\">\n" +
+                        "        <long>0.00</long>\n" +
+                        "        <lat>123.000</lat>\n" +
+                        "        <name>London</name>\n" +
+                        "    </homecity>\n" +
+                        "    <one name=\"elementOne\" id=\"urn:company:namespace:type:id:one\">ValueOne</one>" +
+                        "    <two id=\"urn:company:namespace:type:id:two\" name=\"elementTwo\">ValueTwo</two>" +
+                        "    <three name=\"elementThree\" id=\"urn:company:namespace:type:id:three\" >" +
+                        "        This       is a text   which span across a very     very Very       long line!" +
+                        "    </three>" +
+                        "</person>";
+
+        final String postedXml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<person xmlns=\"http://www.your.example.com/xml/person\">\n" +
+                        "    <age>37</age>\n" +
+                        "    <name>Rob</name>\n" +
+                        "    <one id=\"urn:company:namespace:type:id:one\" name=\"elementOne\" >ValueOne</one>" +
+                        "    <two id=\"urn:company:namespace:type:id:two\" name=\"elementTwo\">ValueTwo</two>" +
+                        "    <three id=\"urn:company:namespace:type:id:three\" name=\"elementThree\">" +
+                        "        This is a     text   which        span across a very very Very long line!" +
+                        "    </three>" +
+                        "    <homecity xmlns=\"http://www.my.example.com/xml/cities\">\n" +
+                        "        <name>London</name>\n" +
+                        "        <lat>123.000</lat>\n" +
+                        "        <long>0.00</long>\n" +
+                        "    </homecity>\n" +
+                        "    <VocabularyElement id=\"urn:epc:idpat:sgtin:0652642.107340\">\n" +
+                        "         <attribute id=\"urn:epcglobal:product:drugName\">Piramidon</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:manufacturer\">Generic Pharma Co.</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:dosageForm\">CAPSULE</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:strength\">125 mg</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:containerSize\">100</attribute>\n" +
+                        "    </VocabularyElement>" +
+                        "</person>";
+
+        StubRequest request = new StubRequest.Builder()
+                .withPost(postedXml)
+                .withHeaderContentType("application/xml")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, stubbedXml, request);
+
+        assertThat(isBodiesMatch).isTrue();
+    }
+
+    @Test
+    public void postBodiesDoNotMatch_ShouldReturnFalse_WhenDifferentXmlWithAttributes() {
+
+        final String stubbedXml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<person xmlns=\"http://www.your.example.com/xml/person\">\n" +
+                        "     <VocabularyElement id=\"urn:epc:idpat:sgtin:0652642.107340\">\n" +
+                        "         <attribute id=\"urn:epcglobal:product:drugName\">Piramidon</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:manufacturer\">Generic Pharma Co.</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:dosageForm\">CAPSULE</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:strength\">125 mg</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:containerSize\">100</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:anotherProperty\">888</attribute>\n" +
+                        "    </VocabularyElement>" +
+                        "    <name>Rob</name>\n" +
+                        "    <age>37</age>\n" +
+                        "    <!--\n" +
+                        "      Hello,\n" +
+                        "         I am a multi-line XML comment\n" +
+                        "         <staticText>\n" +
+                        "            <reportElement x=\"180\" y=\"0\" width=\"200\" height=\"20\"/>\n" +
+                        "            <text><![CDATA[Hello World!]]></text>\n" +
+                        "          </staticText>\n" +
+                        "      -->" +
+                        "    <homecity xmlns=\"http://www.my.example.com/xml/cities\">\n" +
+                        "        <long>0.00</long>\n" +
+                        "        <lat>123.000</lat>\n" +
+                        "        <name>London</name>\n" +
+                        "    </homecity>\n" +
+                        "    <one name=\"elementOne\" id=\"urn:company:namespace:type:id:one\">ValueOne</one>" +
+                        "    <two id=\"urn:company:namespace:type:id:two\" name=\"elementTwo\">ValueTwo</two>" +
+                        "    <three name=\"elementThree\" id=\"urn:company:namespace:type:id:three\" >" +
+                        "        This       is a text   which span across a very     very Very       long line!" +
+                        "    </three>" +
+                        "</person>";
+
+        final String postedXml =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<person xmlns=\"http://www.your.example.com/xml/person\">\n" +
+                        "    <age>37</age>\n" +
+                        "    <name>Rob</name>\n" +
+                        "    <lastName>Schneider</lastName>\n" +
+                        "    <one id=\"urn:company:namespace:type:id:one\" name=\"elementOne\" >ValueOne</one>" +
+                        "    <two id=\"urn:company:namespace:type:id:two\" name=\"elementTwo\">ValueTwo</two>" +
+                        "    <three id=\"urn:company:namespace:type:id:three\" name=\"elementThree\">" +
+                        "        This is a     text   which        span across a very very Very long line!" +
+                        "    </three>" +
+                        "    <homecity xmlns=\"http://www.my.example.com/xml/cities\">\n" +
+                        "        <name>London</name>\n" +
+                        "        <lat>123.000</lat>\n" +
+                        "        <long>0.00</long>\n" +
+                        "    </homecity>\n" +
+                        "    <VocabularyElement id=\"urn:epc:idpat:sgtin:0652642.107340\">\n" +
+                        "         <attribute id=\"urn:epcglobal:product:drugName\">Piramidon</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:manufacturer\">Generic Pharma Co.</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:dosageForm\">CAPSULE</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:strength\">125 mg</attribute>\n" +
+                        "         <attribute id=\"urn:epcglobal:product:containerSize\">100</attribute>\n" +
+                        "    </VocabularyElement>" +
+                        "</person>";
+
+        StubRequest request = new StubRequest.Builder()
+                .withPost(postedXml)
+                .withHeaderContentType("application/xml")
+                .build();
+
+        final boolean isBodiesMatch = stubMatcher.postBodiesMatch(true, stubbedXml, request);
+
+        assertThat(isBodiesMatch).isFalse();
+    }
+
+    @Test
     public void postBodiesMatch_ShouldReturnTrue_WhenEquivalentCustomXml() {
         StubRequest request = new StubRequest.Builder()
                 .withPost("<xml><a>a</a><b>b</b></xml>")

--- a/unit/java/io/github/azagniotov/stubby4j/stubs/StubRepositoryTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/stubs/StubRepositoryTest.java
@@ -4,7 +4,8 @@ import com.google.api.client.http.HttpMethods;
 import io.github.azagniotov.stubby4j.client.StubbyResponse;
 import io.github.azagniotov.stubby4j.common.Common;
 import io.github.azagniotov.stubby4j.http.StubbyHttpTransport;
-import io.github.azagniotov.stubby4j.yaml.YAMLParser;
+import io.github.azagniotov.stubby4j.yaml.YamlParseResultSet;
+import io.github.azagniotov.stubby4j.yaml.YamlParser;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,11 +20,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -32,7 +33,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,8 +42,12 @@ public class StubRepositoryTest {
 
     private static final File CONFIG_FILE = new File("parentPath", "childPath");
 
-    private static final Future<List<StubHttpLifecycle>> COMPLETED_FUTURE =
-            CompletableFuture.completedFuture(new LinkedList<StubHttpLifecycle>());
+    private static final CompletableFuture<YamlParseResultSet> YAML_PARSE_RESULT_SET_FUTURE =
+            CompletableFuture.completedFuture(new YamlParseResultSet(new LinkedList<>(), new HashMap<>()));
+
+    private static final String STUB_UUID_ONE = "9136d8b7-f7a7-478d-97a5-53292484aaf6";
+    private static final String STUB_UUID_TWO = "2387d97d-wlos-v907-8f9s-k2k5h4k5h365";
+    private static final String STUB_UUID_THREE = "9kfhksdjhfwe-wlos-323r-3243-wekfhwek876af";
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -55,7 +59,7 @@ public class StubRepositoryTest {
     private HttpServletRequest mockHttpServletRequest;
 
     @Mock
-    private YAMLParser mockYAMLParser;
+    private YamlParser mockYamlParser;
 
 
     @Captor
@@ -65,7 +69,7 @@ public class StubRepositoryTest {
     private ArgumentCaptor<File> fileCaptor;
 
     @Captor
-    private ArgumentCaptor<List<StubHttpLifecycle>> stubsCaptor;
+    private ArgumentCaptor<YamlParseResultSet> yamlParseResultSetCaptor;
 
     private StubRequest.Builder requestBuilder;
     private StubResponse.Builder responseBuilder;
@@ -77,7 +81,7 @@ public class StubRepositoryTest {
         requestBuilder = new StubRequest.Builder();
         responseBuilder = new StubResponse.Builder();
 
-        final StubRepository stubRepository = new StubRepository(CONFIG_FILE, COMPLETED_FUTURE);
+        final StubRepository stubRepository = new StubRepository(CONFIG_FILE, YAML_PARSE_RESULT_SET_FUTURE);
         final Field stubbyHttpTransportField = stubRepository.getClass().getDeclaredField("stubbyHttpTransport");
         FieldSetter.setField(stubRepository, stubbyHttpTransportField, mockStubbyHttpTransport);
 
@@ -85,9 +89,17 @@ public class StubRepositoryTest {
     }
 
     @Test
+    public void canMatchHttpCycleByUuid() throws Exception {
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        spyStubRepository.resetStubsCache(yamlParseResultSet);
+
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
+    }
+
+    @Test
     public void shouldExpungeOriginalHttpCycleList_WhenNewHttpCyclesGiven() throws Exception {
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
-        final boolean resetResult = spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        final boolean resetResult = spyStubRepository.resetStubsCache(yamlParseResultSet);
 
         assertThat(resetResult).isTrue();
         assertThat(spyStubRepository.getStubs().size()).isGreaterThan(0);
@@ -95,8 +107,8 @@ public class StubRepositoryTest {
 
     @Test
     public void shouldMatchHttplifecycle_WhenValidIndexGiven() throws Exception {
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
-        final boolean resetResult = spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        final boolean resetResult = spyStubRepository.resetStubsCache(yamlParseResultSet);
         assertThat(resetResult).isTrue();
         assertThat(spyStubRepository.getStubs().size()).isGreaterThan(0);
 
@@ -106,8 +118,8 @@ public class StubRepositoryTest {
 
     @Test
     public void shouldNotMatchHttplifecycle_WhenInvalidIndexGiven() throws Exception {
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
-        final boolean resetResult = spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        final boolean resetResult = spyStubRepository.resetStubsCache(yamlParseResultSet);
         assertThat(resetResult).isTrue();
         assertThat(spyStubRepository.getStubs().size()).isGreaterThan(0);
 
@@ -117,25 +129,29 @@ public class StubRepositoryTest {
 
     @Test
     public void shouldDeleteOriginalHttpCycleList_WhenValidIndexGiven() throws Exception {
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
-        final boolean resetResult = spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        final boolean resetResult = spyStubRepository.resetStubsCache(yamlParseResultSet);
         assertThat(resetResult).isTrue();
         assertThat(spyStubRepository.getStubs().size()).isGreaterThan(0);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
 
         final StubHttpLifecycle deletedHttpLifecycle = spyStubRepository.deleteStubByIndex(0);
         assertThat(deletedHttpLifecycle).isNotNull();
         assertThat(spyStubRepository.getStubs()).isEmpty();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isFalse();
     }
 
     @Test
     public void shouldDeleteOriginalHttpCycleList_WhenStubsExist() throws Exception {
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
-        final boolean resetResult = spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        final boolean resetResult = spyStubRepository.resetStubsCache(yamlParseResultSet);
         assertThat(resetResult).isTrue();
         assertThat(spyStubRepository.getStubs().size()).isGreaterThan(0);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
 
         spyStubRepository.deleteAllStubs();
         assertThat(spyStubRepository.getStubs()).isEmpty();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isFalse();
     }
 
     @Test
@@ -149,37 +165,194 @@ public class StubRepositoryTest {
 
         expectedException.expect(IndexOutOfBoundsException.class);
 
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
-        final boolean resetResult = spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        final boolean resetResult = spyStubRepository.resetStubsCache(yamlParseResultSet);
         assertThat(resetResult).isTrue();
         assertThat(spyStubRepository.getStubs().size()).isGreaterThan(0);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
 
         spyStubRepository.deleteStubByIndex(9999);
     }
 
     @Test
+    public void shouldDeleteStubsByUuid() throws Exception {
+        final YamlParseResultSet yamlParseResultSetOne = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        final YamlParseResultSet yamlParseResultSetTwo = parseYaml("/resource/item/2", STUB_UUID_TWO);
+        final YamlParseResultSet yamlParseResultSetThree = parseYaml("/resource/item/3", STUB_UUID_THREE);
+
+        // Setting state for the test
+        spyStubRepository.resetStubsCache(new YamlParseResultSet(new LinkedList<StubHttpLifecycle>() {{
+            addAll(yamlParseResultSetOne.getStubs());
+            addAll(yamlParseResultSetTwo.getStubs());
+            addAll(yamlParseResultSetThree.getStubs());
+        }}, new HashMap<String, StubHttpLifecycle>() {{
+            putAll(yamlParseResultSetOne.getUuidToStubs());
+            putAll(yamlParseResultSetTwo.getUuidToStubs());
+            putAll(yamlParseResultSetThree.getUuidToStubs());
+        }}));
+
+        assertThat(spyStubRepository.getStubs().size()).isEqualTo(3);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_THREE)).isTrue();
+
+        ///////////////////////////////////////////////////////////////////////////////////////
+        // The actual test: deleting by second UUID (STUB_UUID_TWO)
+        ///////////////////////////////////////////////////////////////////////////////////////
+        assertThat(spyStubRepository.deleteStubByUuid(STUB_UUID_TWO)).isNotNull();
+
+        assertThat(spyStubRepository.getStubs().size()).isEqualTo(2);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isFalse();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_THREE)).isTrue();
+
+        // Stubs that left, do not contain deleted URI
+        assertThat(spyStubRepository.getStubs().get(0).getRequest().getUri().equals("/resource/item/2")).isFalse();
+        assertThat(spyStubRepository.getStubs().get(1).getRequest().getUri().equals("/resource/item/2")).isFalse();
+
+
+        ///////////////////////////////////////////////////////////////////////////////////////
+        // The actual test: deleting by third UUID (STUB_UUID_THREE)
+        ///////////////////////////////////////////////////////////////////////////////////////
+        assertThat(spyStubRepository.deleteStubByUuid(STUB_UUID_THREE)).isNotNull();
+
+        assertThat(spyStubRepository.getStubs().size()).isEqualTo(1);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isFalse();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_THREE)).isFalse();
+
+        // Stubs that left, do not contain deleted URI
+        assertThat(spyStubRepository.getStubs().get(0).getRequest().getUri().equals("/resource/item/2")).isFalse();
+        assertThat(spyStubRepository.getStubs().get(0).getRequest().getUri().equals("/resource/item/3")).isFalse();
+
+
+        ///////////////////////////////////////////////////////////////////////////////////////
+        // The actual test: deleting by first UUID (STUB_UUID_ONE)
+        ///////////////////////////////////////////////////////////////////////////////////////
+        assertThat(spyStubRepository.deleteStubByUuid(STUB_UUID_ONE)).isNotNull();
+
+        assertThat(spyStubRepository.getStubs().isEmpty()).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isFalse();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isFalse();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_THREE)).isFalse();
+    }
+
+    @Test
+    public void shouldUpdateStubsByUuid() throws Exception {
+        final YamlParseResultSet yamlParseResultSetOne = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        final YamlParseResultSet yamlParseResultSetTwo = parseYaml("/resource/item/2", STUB_UUID_TWO);
+        final YamlParseResultSet yamlParseResultSetThree = parseYaml("/resource/item/3", STUB_UUID_THREE);
+
+        // Setting state for the test
+        spyStubRepository.resetStubsCache(new YamlParseResultSet(new LinkedList<StubHttpLifecycle>() {{
+            addAll(yamlParseResultSetOne.getStubs());
+            addAll(yamlParseResultSetTwo.getStubs());
+            addAll(yamlParseResultSetThree.getStubs());
+        }}, new HashMap<String, StubHttpLifecycle>() {{
+            putAll(yamlParseResultSetOne.getUuidToStubs());
+            putAll(yamlParseResultSetTwo.getUuidToStubs());
+            putAll(yamlParseResultSetThree.getUuidToStubs());
+        }}));
+
+        assertThat(spyStubRepository.getStubs().size()).isEqualTo(3);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_THREE)).isTrue();
+
+        assertThat(spyStubRepository.getStubs().get(0).getRequest().getUri()).isEqualTo("/resource/item/1");
+        assertThat(spyStubRepository.getStubs().get(1).getRequest().getUri()).isEqualTo("/resource/item/2");
+        assertThat(spyStubRepository.getStubs().get(2).getRequest().getUri()).isEqualTo("/resource/item/3");
+
+        ///////////////////////////////////////////////////////////////////////////////////////
+        // The actual test: update by second UUID (STUB_UUID_TWO)
+        ///////////////////////////////////////////////////////////////////////////////////////
+        spyStubRepository.updateStubByUuid(STUB_UUID_TWO,
+                parseYaml("/resource/completely/new/item/2", STUB_UUID_TWO).getStubs().get(0));
+
+        assertThat(spyStubRepository.getStubs().size()).isEqualTo(3);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_THREE)).isTrue();
+
+        assertThat(spyStubRepository.getStubs().get(0).getRequest().getUri().equals("/resource/item/1")).isTrue();
+        assertThat(spyStubRepository.getStubs().get(1).getRequest().getUri().equals("/resource/completely/new/item/2")).isTrue();
+        assertThat(spyStubRepository.getStubs().get(2).getRequest().getUri().equals("/resource/item/3")).isTrue();
+
+
+        ///////////////////////////////////////////////////////////////////////////////////////
+        // The actual test: update by third UUID (STUB_UUID_THREE)
+        ///////////////////////////////////////////////////////////////////////////////////////
+        spyStubRepository.updateStubByUuid(STUB_UUID_THREE,
+                parseYaml("/resource/completely/new/item/3", STUB_UUID_THREE).getStubs().get(0));
+
+        assertThat(spyStubRepository.getStubs().size()).isEqualTo(3);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_THREE)).isTrue();
+
+        assertThat(spyStubRepository.getStubs().get(0).getRequest().getUri().equals("/resource/item/1")).isTrue();
+        assertThat(spyStubRepository.getStubs().get(1).getRequest().getUri().equals("/resource/completely/new/item/2")).isTrue();
+        assertThat(spyStubRepository.getStubs().get(2).getRequest().getUri().equals("/resource/completely/new/item/3")).isTrue();
+
+
+        ///////////////////////////////////////////////////////////////////////////////////////
+        // The actual test: update by third UUID (STUB_UUID_ONE)
+        ///////////////////////////////////////////////////////////////////////////////////////
+        spyStubRepository.updateStubByUuid(STUB_UUID_ONE,
+                parseYaml("/resource/completely/new/item/1", STUB_UUID_ONE).getStubs().get(0));
+
+        assertThat(spyStubRepository.getStubs().size()).isEqualTo(3);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_THREE)).isTrue();
+
+        assertThat(spyStubRepository.getStubs().get(0).getRequest().getUri().equals("/resource/completely/new/item/1")).isTrue();
+        assertThat(spyStubRepository.getStubs().get(1).getRequest().getUri().equals("/resource/completely/new/item/2")).isTrue();
+        assertThat(spyStubRepository.getStubs().get(2).getRequest().getUri().equals("/resource/completely/new/item/3")).isTrue();
+
+
+        ///////////////////////////////////////////////////////////////////////////////////////
+        // The actual test: update by second UUID (STUB_UUID_TWO) & override with a new UUID
+        ///////////////////////////////////////////////////////////////////////////////////////
+        final String newUuid = "new-uuid-abc-123";
+        spyStubRepository.updateStubByUuid(STUB_UUID_TWO,
+                parseYaml("/resource/completely/new/item/with/new/uuid/2", newUuid).getStubs().get(0));
+
+        assertThat(spyStubRepository.getStubs().size()).isEqualTo(3);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isFalse();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_THREE)).isTrue();
+        assertThat(spyStubRepository.canMatchStubByUuid(newUuid)).isTrue();
+
+        assertThat(spyStubRepository.getStubs().get(0).getRequest().getUri().equals("/resource/completely/new/item/1")).isTrue();
+        assertThat(spyStubRepository.getStubs().get(1).getRequest().getUri().equals("/resource/completely/new/item/with/new/uuid/2")).isTrue();
+        assertThat(spyStubRepository.getStubs().get(1).getUUID().equals(newUuid)).isTrue();
+        assertThat(spyStubRepository.getStubs().get(2).getRequest().getUri().equals("/resource/completely/new/item/3")).isTrue();
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void shouldVerifyExpectedHttpLifeCycles_WhenRefreshingStubbedData() throws Exception {
-        final List<StubHttpLifecycle> expectedStubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
 
-        when(mockYAMLParser.parse(anyString(), any(File.class))).thenReturn(expectedStubs);
+        when(mockYamlParser.parse(anyString(), any(File.class))).thenReturn(yamlParseResultSet);
 
-        spyStubRepository.refreshStubsFromYAMLConfig(mockYAMLParser);
+        spyStubRepository.refreshStubsFromYamlConfig(mockYamlParser);
 
-        verify(mockYAMLParser, times(1)).parse(stringCaptor.capture(), fileCaptor.capture());
-        verify(spyStubRepository, times(1)).resetStubsCache(stubsCaptor.capture());
+        verify(mockYamlParser).parse(stringCaptor.capture(), fileCaptor.capture());
+        verify(spyStubRepository).resetStubsCache(yamlParseResultSetCaptor.capture());
 
-        assertThat(stubsCaptor.getValue()).isEqualTo(expectedStubs);
+        assertThat(yamlParseResultSetCaptor.getValue()).isEqualTo(yamlParseResultSet);
         assertThat(stringCaptor.getValue()).isEqualTo(CONFIG_FILE.getParent());
         assertThat(fileCaptor.getValue()).isEqualTo(CONFIG_FILE);
     }
 
     @Test
     public void shouldGetMarshalledYamlByIndex_WhenValidHttpCycleListIndexGiven() throws Exception {
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
-        spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        spyStubRepository.resetStubsCache(yamlParseResultSet);
 
-        final String actualMarshalledYaml = spyStubRepository.getStubYAMLByIndex(0);
+        final String actualMarshalledYaml = spyStubRepository.getStubYamlByIndex(0);
 
         assertThat(actualMarshalledYaml).isEqualTo("This is marshalled yaml snippet");
     }
@@ -188,28 +361,31 @@ public class StubRepositoryTest {
     public void shouldFailToGetMarshalledYamlByIndex_WhenInvalidHttpCycleListIndexGiven() throws Exception {
         expectedException.expect(IndexOutOfBoundsException.class);
 
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse("/resource/item/1");
-        spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml("/resource/item/1", STUB_UUID_ONE);
+        spyStubRepository.resetStubsCache(yamlParseResultSet);
 
-        spyStubRepository.getStubYAMLByIndex(10);
+        spyStubRepository.getStubYamlByIndex(10);
     }
 
     @Test
     public void shouldUpdateStubHttpLifecycleByIndex_WhenValidHttpCycleListIndexGiven() throws Exception {
         final String expectedOriginalUrl = "/resource/item/1";
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse(expectedOriginalUrl);
-        spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml(expectedOriginalUrl, STUB_UUID_ONE);
+        spyStubRepository.resetStubsCache(yamlParseResultSet);
         final StubRequest stubbedRequest = spyStubRepository.getStubs().get(0).getRequest();
 
         assertThat(stubbedRequest.getUrl()).isEqualTo(expectedOriginalUrl);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
 
         final String expectedNewUrl = "/resource/completely/new";
-        final List<StubHttpLifecycle> newHttpLifecycles = buildHttpLifeCyclesWithDefaultResponse(expectedNewUrl);
-        final StubHttpLifecycle newStubHttpLifecycle = newHttpLifecycles.get(0);
+        final YamlParseResultSet newYamlParseResultSet = parseYaml(expectedNewUrl, STUB_UUID_TWO);
+        final StubHttpLifecycle newStubHttpLifecycle = newYamlParseResultSet.getStubs().get(0);
         spyStubRepository.updateStubByIndex(0, newStubHttpLifecycle);
         final StubRequest stubbedNewRequest = spyStubRepository.getStubs().get(0).getRequest();
 
         assertThat(stubbedNewRequest.getUrl()).isEqualTo(expectedNewUrl);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isFalse();
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_TWO)).isTrue();
     }
 
     @Test
@@ -217,15 +393,16 @@ public class StubRepositoryTest {
         expectedException.expect(IndexOutOfBoundsException.class);
 
         final String expectedOriginalUrl = "/resource/item/1";
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithDefaultResponse(expectedOriginalUrl);
-        spyStubRepository.resetStubsCache(stubs);
+        final YamlParseResultSet yamlParseResultSet = parseYaml(expectedOriginalUrl, STUB_UUID_ONE);
+        spyStubRepository.resetStubsCache(yamlParseResultSet);
         final StubRequest stubbedRequest = spyStubRepository.getStubs().get(0).getRequest();
 
         assertThat(stubbedRequest.getUrl()).isEqualTo(expectedOriginalUrl);
+        assertThat(spyStubRepository.canMatchStubByUuid(STUB_UUID_ONE)).isTrue();
 
         final String expectedNewUrl = "/resource/completely/new";
-        final List<StubHttpLifecycle> newHttpLifecycles = buildHttpLifeCyclesWithDefaultResponse(expectedNewUrl);
-        final StubHttpLifecycle newStubHttpLifecycle = newHttpLifecycles.get(0);
+        final YamlParseResultSet newYamlParseResultSet = parseYaml(expectedNewUrl, STUB_UUID_ONE);
+        final StubHttpLifecycle newStubHttpLifecycle = newYamlParseResultSet.getStubs().get(0);
         spyStubRepository.updateStubByIndex(10, newStubHttpLifecycle);
     }
 
@@ -233,9 +410,9 @@ public class StubRepositoryTest {
     public void shouldUpdateStubResponseBody_WhenResponseIsRecordable() throws Exception {
         final String sourceToRecord = "http://google.com";
         final String expectedOriginalUrl = "/resource/item/1";
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithCustomResponse(expectedOriginalUrl, responseBuilder.emptyWithBody(sourceToRecord).build());
+        final YamlParseResultSet yamlParseResultSet = parseYaml(expectedOriginalUrl, responseBuilder.emptyWithBody(sourceToRecord).build(), STUB_UUID_ONE);
 
-        spyStubRepository.resetStubsCache(stubs);
+        spyStubRepository.resetStubsCache(yamlParseResultSet);
 
         final StubResponse stubbedResponse = spyStubRepository.getStubs().get(0).getResponse(true);
         assertThat(stubbedResponse.getBody()).isEqualTo(sourceToRecord);
@@ -245,6 +422,7 @@ public class StubRepositoryTest {
         final StubRequest stubbedRequest = spyStubRepository.getStubs().get(0).getRequest();
         when(mockStubbyHttpTransport.fetchRecordableHTTPResponse(eq(stubbedRequest), anyString())).thenReturn(new StubbyResponse(200, actualResponseText));
 
+        final List<StubHttpLifecycle> stubs = yamlParseResultSet.getStubs();
         for (int idx = 0; idx < 5; idx++) {
             doReturn(stubs.get(0).getRequest()).when(spyStubRepository).toStubRequest(any(HttpServletRequest.class));
             final StubSearchResult stubSearchResult = spyStubRepository.search(mockHttpServletRequest);
@@ -255,20 +433,22 @@ public class StubRepositoryTest {
             assertThat(stubbedResponse.getBody()).isEqualTo(recordedResponse.getBody());
             assertThat(stubbedResponse.isRecordingRequired()).isFalse();
         }
-        verify(mockStubbyHttpTransport, times(1)).fetchRecordableHTTPResponse(eq(stubbedRequest), anyString());
+        verify(mockStubbyHttpTransport).fetchRecordableHTTPResponse(eq(stubbedRequest), anyString());
     }
 
     @Test
     public void shouldNotUpdateStubResponseBody_WhenResponseIsNotRecordable() throws Exception {
         final String recordingSource = "htt://google.com";  //makes it non recordable
         final String expectedOriginalUrl = "/resource/item/1";
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithCustomResponse(expectedOriginalUrl, responseBuilder.emptyWithBody(recordingSource).build());
+        final YamlParseResultSet yamlParseResultSet = parseYaml(expectedOriginalUrl,
+                responseBuilder.emptyWithBody(recordingSource).build(), STUB_UUID_ONE);
 
-        spyStubRepository.resetStubsCache(stubs);
+        spyStubRepository.resetStubsCache(yamlParseResultSet);
 
         final StubResponse expectedResponse = spyStubRepository.getStubs().get(0).getResponse(true);
         assertThat(expectedResponse.getBody()).isEqualTo(recordingSource);
 
+        final List<StubHttpLifecycle> stubs = yamlParseResultSet.getStubs();
         doReturn(stubs.get(0).getRequest()).when(spyStubRepository).toStubRequest(any(HttpServletRequest.class));
         final StubSearchResult stubSearchResult = spyStubRepository.search(mockHttpServletRequest);
         final StubResponse failedToRecordResponse = stubSearchResult.getMatch();
@@ -288,9 +468,10 @@ public class StubRepositoryTest {
                         .withQuery("queryOne", "([a-zA-Z]+)")
                         .withQuery("queryTwo", "([1-9]+)")
                         .build();
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithCustomResponse(stubbedRequest, responseBuilder.emptyWithBody(sourceToRecord).build());
+        final YamlParseResultSet yamlParseResultSet = parseYaml(stubbedRequest,
+                responseBuilder.emptyWithBody(sourceToRecord).build(), STUB_UUID_ONE);
 
-        spyStubRepository.resetStubsCache(stubs);
+        spyStubRepository.resetStubsCache(yamlParseResultSet);
 
         final String actualResponseText = "OK, this is recorded response text!";
         when(mockStubbyHttpTransport.fetchRecordableHTTPResponse(eq(stubbedRequest), stringCaptor.capture())).thenReturn(new StubbyResponse(200, actualResponseText));
@@ -316,9 +497,10 @@ public class StubRepositoryTest {
     public void shouldNotUpdateStubResponseBody_WhenResponseIsRecordableButExceptionThrown() throws Exception {
         final String recordingSource = "http://google.com";
         final String expectedOriginalUrl = "/resource/item/1";
-        final List<StubHttpLifecycle> stubs = buildHttpLifeCyclesWithCustomResponse(expectedOriginalUrl, responseBuilder.emptyWithBody(recordingSource).build());
+        final YamlParseResultSet yamlParseResultSet = parseYaml(expectedOriginalUrl,
+                responseBuilder.emptyWithBody(recordingSource).build(), STUB_UUID_ONE);
 
-        spyStubRepository.resetStubsCache(stubs);
+        spyStubRepository.resetStubsCache(yamlParseResultSet);
 
         final StubResponse expectedResponse = spyStubRepository.getStubs().get(0).getResponse(true);
         assertThat(expectedResponse.getBody()).isEqualTo(recordingSource);
@@ -326,6 +508,7 @@ public class StubRepositoryTest {
         final StubRequest matchedRequest = spyStubRepository.getStubs().get(0).getRequest();
         when(mockStubbyHttpTransport.fetchRecordableHTTPResponse(eq(matchedRequest), anyString())).thenThrow(Exception.class);
 
+        final List<StubHttpLifecycle> stubs = yamlParseResultSet.getStubs();
         doReturn(stubs.get(0).getRequest()).when(spyStubRepository).toStubRequest(any(HttpServletRequest.class));
         final StubSearchResult stubSearchResult = spyStubRepository.search(mockHttpServletRequest);
         final StubResponse actualResponse = stubSearchResult.getMatch();
@@ -558,11 +741,11 @@ public class StubRepositoryTest {
         assertThat(assertingRequest).isNotEqualTo(expectedRequest);
     }
 
-    private List<StubHttpLifecycle> buildHttpLifeCyclesWithDefaultResponse(final String url) throws Exception {
-        return buildHttpLifeCyclesWithCustomResponse(url, StubResponse.okResponse());
+    private YamlParseResultSet parseYaml(final String url, final String uuid) throws Exception {
+        return parseYaml(url, StubResponse.okResponse(), uuid);
     }
 
-    private List<StubHttpLifecycle> buildHttpLifeCyclesWithCustomResponse(final String url, final StubResponse stubResponse) throws Exception {
+    private YamlParseResultSet parseYaml(final String url, final StubResponse stubResponse, final String uuid) throws Exception {
         final StubRequest stubRequest =
                 requestBuilder
                         .withUrl(url)
@@ -570,17 +753,22 @@ public class StubRepositoryTest {
                         .withHeader("content-type", Common.HEADER_APPLICATION_JSON)
                         .build();
 
-        return buildHttpLifeCyclesWithCustomResponse(stubRequest, stubResponse);
+        return parseYaml(stubRequest, stubResponse, uuid);
     }
 
-    private List<StubHttpLifecycle> buildHttpLifeCyclesWithCustomResponse(final StubRequest stubRequest, final StubResponse stubResponse) throws Exception {
+    private YamlParseResultSet parseYaml(final StubRequest stubRequest, final StubResponse stubResponse, final String uuid) throws Exception {
         final StubHttpLifecycle.Builder stubBuilder = new StubHttpLifecycle.Builder();
         stubBuilder.withRequest(stubRequest)
                 .withResponse(stubResponse)
+                .withUUID(uuid)
                 .withCompleteYAML("This is marshalled yaml snippet");
 
-        return new LinkedList<StubHttpLifecycle>() {{
-            add(stubBuilder.build());
-        }};
+        final StubHttpLifecycle stubHttpLifecycle = stubBuilder.build();
+
+        return new YamlParseResultSet(new LinkedList<StubHttpLifecycle>() {{
+            add(stubHttpLifecycle);
+        }}, new HashMap<String, StubHttpLifecycle>() {{
+            put(stubHttpLifecycle.getUUID(), stubHttpLifecycle);
+        }});
     }
 }

--- a/unit/java/io/github/azagniotov/stubby4j/utils/DateTimeUtilsTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/utils/DateTimeUtilsTest.java
@@ -1,0 +1,34 @@
+package io.github.azagniotov.stubby4j.utils;
+
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class DateTimeUtilsTest {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd HH:mm:ssZ")
+            .withZone(ZoneOffset.systemDefault());
+
+    @Test
+    public void systemDefault() throws Exception {
+        final String localNow = DATE_TIME_FORMATTER.format(Instant.now());
+        final String systemDefault = DateTimeUtils.systemDefault();
+
+        assertThat(localNow).isEqualTo(systemDefault);
+    }
+
+    @Test
+    public void systemDefaultFromMillis() throws Exception {
+        final long currentTimeMillis = System.currentTimeMillis();
+        final String localNow = DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(currentTimeMillis));
+
+        final String systemDefault = DateTimeUtils.systemDefault(currentTimeMillis);
+
+        assertThat(localNow).isEqualTo(systemDefault);
+    }
+}

--- a/unit/java/io/github/azagniotov/stubby4j/utils/StringUtilsTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/utils/StringUtilsTest.java
@@ -27,9 +27,16 @@ public class StringUtilsTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Test
+    public void isNumeric() throws Exception {
+        assertThat(StringUtils.isNumeric("9136d8b7-f7a7-478d-97a5-53292484aaf6")).isFalse();
+        assertThat(StringUtils.isNumeric("8-88")).isFalse();
+        assertThat(StringUtils.isNumeric("888")).isTrue();
+    }
+
+    @Test
     public void shouldConvertObjectToString_WhenObjectIsNotNull() throws Exception {
 
-        final String result = StringUtils.objectToString(new Integer(888));
+        final String result = StringUtils.objectToString(888);
 
         assertThat(result).isEqualTo("888");
     }

--- a/unit/java/io/github/azagniotov/stubby4j/yaml/YamlBuilderTest.java
+++ b/unit/java/io/github/azagniotov/stubby4j/yaml/YamlBuilderTest.java
@@ -5,19 +5,20 @@ import io.github.azagniotov.stubby4j.utils.FileUtils;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.github.azagniotov.stubby4j.stubs.StubbableAuthorizationType.*;
+import static io.github.azagniotov.stubby4j.stubs.StubbableAuthorizationType.BASIC;
+import static io.github.azagniotov.stubby4j.stubs.StubbableAuthorizationType.BEARER;
+import static io.github.azagniotov.stubby4j.stubs.StubbableAuthorizationType.CUSTOM;
 
 
-public class YAMLBuilderTest {
+public class YamlBuilderTest {
 
     @Test
     public void shouldBuildStubbedResponseWithSequenceResponses() throws Exception {
         final String expectedYaml =
-                "-  request:" + FileUtils.BR +
+                        "-  description: Hello!" + FileUtils.BR +
+                        "   request:" + FileUtils.BR +
                         "      method: [PUT]" + FileUtils.BR +
                         "      url: /invoice" + FileUtils.BR +
-                        "" + FileUtils.BR +
-                        "   description: Hello!" + FileUtils.BR +
                         "" + FileUtils.BR +
                         "   response:" + FileUtils.BR +
                         "      -  status: 200" + FileUtils.BR +
@@ -36,12 +37,13 @@ public class YAMLBuilderTest {
                         "         body: OMFG!!!" + FileUtils.BR +
                         "         file: ../../response.json";
 
-        final YAMLBuilder YAMLBuilder = new YAMLBuilder();
-        final String actualYaml = YAMLBuilder
+        final YamlBuilder yamlBuilder = new YamlBuilder();
+        final String actualYaml = yamlBuilder
+                .newStubbedFeature()
+                .withDescription("Hello!")
                 .newStubbedRequest()
                 .withMethodPut()
                 .withUrl("/invoice")
-                .withDescription("Hello!")
                 .newStubbedResponse()
                 .withSequenceResponseStatus("200")
                 .withSequenceResponseHeaders("content-type", Common.HEADER_APPLICATION_JSON)
@@ -86,8 +88,8 @@ public class YAMLBuilderTest {
                         "            content-type: application/json" + FileUtils.BR +
                         "         file: ../path/to/error.file";
 
-        final YAMLBuilder YAMLBuilder = new YAMLBuilder();
-        final String actualYaml = YAMLBuilder
+        final YamlBuilder YamlBuilder = new YamlBuilder();
+        final String actualYaml = YamlBuilder
                 .newStubbedRequest()
                 .withMethodPut()
                 .withUrl("/invoice")
@@ -121,8 +123,8 @@ public class YAMLBuilderTest {
                         "      status: 200" + FileUtils.BR +
                         "      body: OK";
 
-        final YAMLBuilder YAMLBuilder = new YAMLBuilder();
-        final String actualYaml = YAMLBuilder.
+        final YamlBuilder YamlBuilder = new YamlBuilder();
+        final String actualYaml = YamlBuilder.
                 newStubbedRequest().
                 withMethodHead().
                 withMethodGet().
@@ -153,8 +155,8 @@ public class YAMLBuilderTest {
                         "      status: 200" + FileUtils.BR +
                         "      file: ../json/systemtest-body-response-as-file.json";
 
-        final YAMLBuilder YAMLBuilder = new YAMLBuilder();
-        final String actualYaml = YAMLBuilder.
+        final YamlBuilder YamlBuilder = new YamlBuilder();
+        final String actualYaml = YamlBuilder.
                 newStubbedRequest().
                 withQuery("status", "active").
                 withQuery("type", "full").
@@ -191,8 +193,8 @@ public class YAMLBuilderTest {
                         "      body: >" + FileUtils.BR +
                         "         {\"id\": \"123\", \"status\": \"updated\"}";
 
-        final YAMLBuilder YAMLBuilder = new YAMLBuilder();
-        final String actualYaml = YAMLBuilder.
+        final YamlBuilder YamlBuilder = new YamlBuilder();
+        final String actualYaml = YamlBuilder.
                 newStubbedRequest().
                 withMethodPut().
                 withUrl("/invoice/123").
@@ -231,8 +233,8 @@ public class YAMLBuilderTest {
                         "         pragma: no-cache" + FileUtils.BR +
                         "         location: /invoice/exit";
 
-        final YAMLBuilder YAMLBuilder = new YAMLBuilder();
-        final String actualYaml = YAMLBuilder.
+        final YamlBuilder YamlBuilder = new YamlBuilder();
+        final String actualYaml = YamlBuilder.
                 newStubbedRequest().
                 withHeaderContentType(Common.HEADER_APPLICATION_JSON).
                 withHeaderContentLanguage("US-en").


### PR DESCRIPTION
- Added support for optional `uuid` property in YAML config
  - Added ability to GET stub by UUID by making a request to Admin portal API
  - Added ability to DELETE stub by UUID by making a request to Admin portal API
  - Added ability to UPDATE stub by UUID by making a request to Admin portal API
- Displaying UUID value in popup dialogs in Admin console when `[view]` YAML source button is clicked
- Revisited HTTP response codes of Admin portal APIs that manage stubs (delete, get & update APIs)
- Upgraded from Jetty `9.4.8.v20171121` to `9.4.9.v20180320`
- Using `ehCache` `v3.5.2` for internal caching
- Moved from `XMLUnit v1.x` to `XMLUnit v2.x` for a more optimized XML evaluation
- Upon parsing of YAML config, Compiling regex patterns using different flag combinations: 
  - `Pattern.MULTILINE`
  - `Pattern.MULTILINE | Pattern.DOTALL`
  - `Pattern.LITERAL` (as a fallback if any of the aforementioned compilations failed)