### PR TITLE
Update SnakeYAML dependency from 1.23 to 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Run `gradle cobertura` command to:
 * jetty-server:9.4.9.v20180320
 * jetty-servlets:9.4.9.v20180320
 * commons-cli:1.2
-* snakeyaml:1.23
+* snakeyaml:1.26
 * jsonassert:1.3.0
 * xmlunit-core:2.5.1
 * ehcache:3.5.2

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = 'Gradle configuration for stubby4j'
 buildscript {
     repositories {
         mavenLocal()
-        mavenCentral()
+        maven { url "https://repo.maven.apache.org/maven2" }
         jcenter()
     }
     dependencies {
@@ -30,7 +30,7 @@ subprojects {
     subproject ->
         repositories {
             mavenLocal()
-            mavenCentral()
+            maven { url "https://repo.maven.apache.org/maven2" }
             jcenter()
         }
         sourceCompatibility = 1.8

--- a/conf/gradle/dependency.gradle
+++ b/conf/gradle/dependency.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile "org.eclipse.jetty:jetty-servlets:9.4.9.v20180320"
     compile "org.ehcache:ehcache:3.5.2"
     compile "commons-cli:commons-cli:1.2"
-    compile "org.yaml:snakeyaml:1.23"
+    compile "org.yaml:snakeyaml:1.26"
     compile "org.skyscreamer:jsonassert:1.3.0"
     compile 'org.xmlunit:xmlunit-core:2.5.1'
     compile "io.github.azagniotov:collection-type-safe-converter:1.0.1"


### PR DESCRIPTION
Fixes #106 

I had to replace mavenCentral() with the specific maven URL because it seems mavenCentral() on Gradle 2.0 uses the HTTP endpoint and that is no longer supported (returns a 501).

In addition one of the tests is failing for me:

```
io.github.azagniotov.stubby4j.StubsPortalTest > shouldReturnReplacedValueInLocationHeaderWhenQueryParamHasDynamicToken FAILED
    java.lang.AssertionError: 
    Expected: (an instance of java.net.UnknownHostException and exception with message a string containing "alex.com")
         but: an instance of java.net.UnknownHostException <java.net.ConnectException: Connection refused (Connection refused)> is a java.net.ConnectException
```

This is possibly due to a change in a Java version? (I was testing with Java 8)
