### PR TITLE
Clearer log output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Log file
 *.log
+**/logs/*
 
 # BlueJ files
 *.ctxt

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * PR [#284](https://github.com/azagniotov/stubby4j/pull/284) - During YAML parsing, checking if configured properties belong in their respective top-level objects (https://github.com/azagniotov)
 * PR [#286](https://github.com/azagniotov/stubby4j/pull/286) - Upgraded jetty to `9.4.43.v20210629` and SnakeYAML to `v1.29` (https://github.com/azagniotov)
+* PR [#295](https://github.com/azagniotov/stubby4j/pull/295) - When matching stubs, the log output is now clearer what has been matched (https://github.com/azagniotov)
 
 #### 7.3.3
 


### PR DESCRIPTION
When matching stubs, the log output is now clearer what has been matched