### PR TITLE
Upgraded log4j to 2.16.0 to patch vulnerability

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.parallel=true
 configureondemand=true
 org.gradle.vfs.watch=true
 
-log4j2Version=2.14.1
+log4j2Version=2.16.0
 xmlUnitVersion=2.8.2
 jettyVersion=9.4.44.v20210927
 snakeYamlVersion=1.29


### PR DESCRIPTION
This PR is related to the changes advised by the Apache Foundation in https://logging.apache.org/log4j/2.x/security.html as part of workaround to the recently discovered vulnerabilities in log4j 2.x.x