### PR TITLE
Addressing CVE-2021-45105

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.parallel=true
 configureondemand=true
 org.gradle.vfs.watch=true
 
-log4j2Version=2.16.0
+log4j2Version=2.17.0
 xmlUnitVersion=2.8.2
 jettyVersion=9.4.44.v20210927
 snakeYamlVersion=1.29


### PR DESCRIPTION
- https://logging.apache.org/log4j/2.x/security.html
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105