### PR TITLE
Upgraded jetty to v9.4.53.v20231009

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.vfs.watch=true
 
 log4j2Version=2.17.1
 xmlUnitVersion=2.8.4
-jettyVersion=9.4.44.v20210927
+jettyVersion=9.4.53.v20231009
 snakeYamlVersion=2.2
 mockitoVersion=3.12.4
 


### PR DESCRIPTION
End of Community Support for Jetty 9.x - June 2022
- https://github.com/jetty/jetty.project/issues/7958

Includes various CVE fixes